### PR TITLE
fix: Set CameraPositionState.position when using .move()

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
@@ -46,6 +46,10 @@ internal class MapPropertiesNode(
     override fun onAttached() {
         map.setOnCameraIdleListener {
             cameraPositionState.isMoving = false
+            // setOnCameraMoveListener is only invoked when the camera position
+            // is changed via .animate(). To handle updating state when .move()
+            // is used, it's necessary to set the camera's position here as well
+            cameraPositionState.rawPosition = map.cameraPosition
         }
         map.setOnCameraMoveCanceledListener {
             cameraPositionState.isMoving = false


### PR DESCRIPTION
Fixes #15
