### PR TITLE
ci: Ignore gh-pages branch for test workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ on:
   repository_dispatch:
     types: [test]
   push:
-    branches: ['*']
+    branches-ignore: ['gh-pages']
   pull_request:
-    branches: ['*']
+    branches-ignore: ['gh-pages']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Disable testing on `gh-pages` branch.
