### PR TITLE
Fixed Collection contains no element matching the predicate.

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
@@ -15,14 +15,9 @@
 package com.google.maps.android.compose
 
 import androidx.compose.runtime.AbstractApplier
-import androidx.compose.ui.platform.ComposeView
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.MapView
-import com.google.android.gms.maps.model.Circle
-import com.google.android.gms.maps.model.GroundOverlay
-import com.google.android.gms.maps.model.Marker
-import com.google.android.gms.maps.model.Polygon
-import com.google.android.gms.maps.model.Polyline
+import com.google.android.gms.maps.model.*
 
 internal interface MapNode {
     fun onAttached() {}
@@ -139,16 +134,16 @@ internal class MapApplier(
 }
 
 private fun MutableList<MapNode>.nodeForCircle(circle: Circle): CircleNode? =
-    first { it is CircleNode && it.circle == circle } as? CircleNode
+    firstOrNull { it is CircleNode && it.circle == circle } as? CircleNode
 
 private fun MutableList<MapNode>.nodeForMarker(marker: Marker): MarkerNode? =
-    first { it is MarkerNode && it.marker == marker } as? MarkerNode
+    firstOrNull { it is MarkerNode && it.marker == marker } as? MarkerNode
 
 private fun MutableList<MapNode>.nodeForPolygon(polygon: Polygon): PolygonNode? =
-    first { it is PolygonNode && it.polygon == polygon } as? PolygonNode
+    firstOrNull { it is PolygonNode && it.polygon == polygon } as? PolygonNode
 
 private fun MutableList<MapNode>.nodeForPolyline(polyline: Polyline): PolylineNode? =
-    first { it is PolylineNode && it.polyline == polyline } as? PolylineNode
+    firstOrNull { it is PolylineNode && it.polyline == polyline } as? PolylineNode
 
 private fun MutableList<MapNode>.nodeForGroundOverlay(
     groundOverlay: GroundOverlay


### PR DESCRIPTION
This PR fixes the case where none of the elements in the collection is matching the predicate. I believe this happens when markers are removed and the info window is still open (or some other case modifying the markers, when they are no longer present on the map.

StackTrace:

`


Fatal Exception: java.util.NoSuchElementException
Collection contains no element matching the predicate.
com.google.maps.android.compose.MapApplierKt.nodeForMarker (MapApplierKt.java:161)
com.google.maps.android.compose.MapApplierKt.access$nodeForMarker (MapApplierKt.java:1)
com.google.maps.android.compose.MapApplier.attachClickListeners$lambda-7 (MapApplier.java:104)
com.google.maps.android.compose.MapApplier$$InternalSyntheticLambda$0$482fd6de2d7abe2a9115f12176c811e781b09364225b40910764579698c22538$6.onInfoWindowClose (MapApplier.java:2)
com.google.android.gms.maps.zze.zzb (com.google.android.gms:play-services-maps@@18.0.0:1)
com.google.android.gms.maps.internal.zzae.zza (com.google.android.gms:play-services-maps@@18.0.0:2)
com.google.android.gms.internal.maps.zzb.onTransact (com.google.android.gms:play-services-maps@@18.0.0:3)
android.os.Binder.transact (Binder.java:1064)
arq.bl (arq.java:2)
com.google.maps.api.android.lib6.impl.dd.d (dd.java:3)
com.google.maps.api.android.lib6.phoenix.w.run (w.java)
android.os.Handler.handleCallback (Handler.java:938)
android.os.Handler.dispatchMessage (Handler.java:99)
android.os.Looper.loopOnce (Looper.java:201)
android.os.Looper.loop (Looper.java:288)
android.app.ActivityThread.main (ActivityThread.java:7842)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1003)
`