### PR TITLE
chore: Fix recommendation on setting the camera's position.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,29 +21,24 @@ Adding a map to your app looks like the following:
 
 ```kotlin
 val singapore = LatLng(1.35, 103.87)
+val cameraPositionState = rememberCameraPositionState {
+    position = CameraPosition.fromLatLngZoom(singapore, 10f)
+}
 GoogleMap(
     modifier = Modifier.fillMaxSize(),
-    googleMapOptionsFactory = {
-        GoogleMapOptions().camera(CameraPosition.fromLatLngZoom(singapore, 10f))
-    }
+    cameraPositionState = cameraPositionState
 )
 ```
 
 ### Creating and configuring a map
 
-Configuring the map can be done either by passing a `GoogleMapOptions` instance 
-to initialize the map, or by passing a `MapProperties` object into the `GoogleMap`
-composable.
+Configuring the map can be done by passing a `MapProperties` object into the 
+`GoogleMap` composable. For anything not available in `MapProperties` (typically 
+anything that can only be provided once - like map ID), provide a 
+`GoogleMapOptions` instance in the `googleMapOptionsFactory` properties instead.
 
 ```kotlin
-// Initialize map by providing a googleMapOptionsFactory
-GoogleMap(
-    googleMapOptionsFactory = {
-        GoogleMapOptions().mapId("MyMapId")
-    }
-)
-
-// ...or set properties using MapProperties which you can use to recompose the map
+// Set properties using MapProperties which you can use to recompose the map
 var mapProperties by remember {
     mutableStateOf(
         MapProperties(maxZoomPreference = 10f, minZoomPreference = 5f)
@@ -59,11 +54,25 @@ Box(Modifier.fillMaxSize()) {
         Text(text = "Toggle isBuildingEnabled")
     }
 }
+
+// ...or initialize the map by providing a googleMapOptionsFactory
+// This should only be used for values that do not recompose the map such as
+// map ID.
+GoogleMap(
+    googleMapOptionsFactory = {
+        GoogleMapOptions().mapId("MyMapId")
+    }
+)
+
 ```
 
 ### Controlling a map's camera
 
 Camera changes and updates can be observed and controlled via `CameraPositionState`.
+
+**Note**: `CameraPositionState` is the source of truth for anything camera 
+related. So, providing a camera position in `GoogleMapOptions` will be 
+overridden by `CameraPosition`.
 
 ```kotlin
 val singapore = LatLng(1.35, 103.87)

--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -118,14 +118,6 @@ private fun GoogleMapView(modifier: Modifier, onMapLoaded: () -> Unit) {
         properties = mapProperties,
         uiSettings = uiSettings,
         onMapLoaded = onMapLoaded,
-        googleMapOptionsFactory = {
-            GoogleMapOptions().camera(
-                CameraPosition.fromLatLngZoom(
-                    singapore,
-                    11f
-                )
-            )
-        },
         onPOIClick = {
             Log.d(TAG, "POI clicked: ${it.name}")
         }


### PR DESCRIPTION
Clarify in the README that `CameraPositionState` and `MapProperties` should be used for anything that recomposes the map. Conversely, `GoogleMapOptions` should only be used for initializing the map (properties that can only be provided in map initialization like map ID).

The documentation page in https://developers.google.com/maps/documentation/android-sdk/maps-compose#add_a_map_to_your_app will also be updated shortly.

Fixes #42 🦕
