### PR TITLE
docs: Link releases for required version of Compose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains [Jetpack Compose][jetpack-compose] components for the M
 
 ## Requirements
 * Kotlin-enabled project
-* Jetpack Compose-enabled project
+* Jetpack Compose-enabled project (see [releases](https://github.com/googlemaps/android-maps-compose/releases) for the required version of Jetpack Compose)
 * An [API key][api-key]
 * API level 21+
 


### PR DESCRIPTION
Link to releases page to help find the required version of Jetpack Compose for a given library version. The appropriate release notes have been updated to mention when the version of Jetpack Compose was bumped.

Fixes #64 🦕
