### PR TITLE
chore: Support snapshot releases

### DIFF
--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -158,7 +158,7 @@ fun GoogleMapView(
             Text(it.title ?: "Title", color = Color.Blue)
         }
         Marker(
-            position = singapore3,
+            positionState = MarkerPositionState(position = singapore3),
             title = "Marker in Singapore",
             onClick = markerClick
         )

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext.projectArtifactId = { project ->
 
 allprojects {
     group = 'com.google.maps.android'
-    version = '1.3.1'
+    version = '2.0.0-SNAPSHOT'
     project.ext.artifactId = rootProject.ext.projectArtifactId(project)
 }
 
@@ -125,8 +125,10 @@ subprojects { project ->
 
         repositories {
             maven {
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
                 name = "mavencentral"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                url = project.version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
                 credentials {
                     username sonatypeUsername
                     password sonatypePassword


### PR DESCRIPTION
Support snapshots and also bumps version to `2.0.0-SNAPSHOT`.

Fixes #60 🦕
