### PR TITLE
chore: Maps Compose 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,14 @@ composable elements to the content of the `GoogleMap`.
 GoogleMap(
   //...
 ) {
-    Marker(position = LatLng(-34, 151), title = "Marker in Sydney")
-    Marker(position = LatLng(35.66, 139.6), title = "Marker in Tokyo")
+    Marker(
+        state = MarkerState(position = LatLng(-34, 151)),
+        title = "Marker in Sydney"
+    )
+    Marker(
+        state = MarkerState(position = LatLng(35.66, 139.6)),
+        title = "Marker in Tokyo"
+    )
 }
 ```
 

--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -101,7 +101,7 @@ class GoogleMapViewTests {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
             }
-            composeTestRule.waitUntil(1000) {
+            composeTestRule.waitUntil(3000) {
                 !cameraPositionState.isMoving
             }
             assertEquals(
@@ -118,7 +118,7 @@ class GoogleMapViewTests {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
             }
-            composeTestRule.waitUntil(1000) {
+            composeTestRule.waitUntil(3000) {
                 !cameraPositionState.isMoving
             }
             assertEquals(
@@ -135,7 +135,7 @@ class GoogleMapViewTests {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
             }
-            composeTestRule.waitUntil(1000) {
+            composeTestRule.waitUntil(3000) {
                 !cameraPositionState.isMoving
             }
             assertEquals(
@@ -182,6 +182,30 @@ class GoogleMapViewTests {
         assertFalse(
             projection!!.visibleRegion.latLngBounds.contains(latLng)
         )
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun testMarkerStateCannotBeReused() {
+        val countDownLatch = CountDownLatch(1)
+        composeTestRule.setContent {
+            GoogleMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraPositionState = cameraPositionState,
+                onMapLoaded = {
+                    countDownLatch.countDown()
+                }
+            ) {
+                val markerState = rememberMarkerState()
+                Marker(
+                    state = markerState
+                )
+                Marker(
+                    state = markerState
+                )
+            }
+        }
+        val mapLoaded = countDownLatch.await(30, TimeUnit.SECONDS)
+        assertTrue(mapLoaded)
     }
 
     private fun zoom(

--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -109,11 +109,12 @@ fun GoogleMapView(
     cameraPositionState: CameraPositionState,
     onMapLoaded: () -> Unit,
 ) {
-    val singaporePositionState = rememberMarkerPositionState(position = singapore)
-    val singapore2PositionState = rememberMarkerPositionState(position = singapore2)
-    var circlePositionState by remember { mutableStateOf(singapore) }
-    if (singaporePositionState.dragState == DragState.END) {
-        circlePositionState = singaporePositionState.position
+    val singaporeState = rememberMarkerState(position = singapore)
+    val singapore2State = rememberMarkerState(position = singapore2)
+    val singapore3State = rememberMarkerState(position = singapore3)
+    var circleCenter by remember { mutableStateOf(singapore) }
+    if (singaporeState.dragState == DragState.END) {
+        circleCenter = singaporeState.position
     }
 
     var uiSettings by remember { mutableStateOf(MapUiSettings(compassEnabled = false)) }
@@ -142,7 +143,7 @@ fun GoogleMapView(
             false
         }
         MarkerInfoWindowContent(
-            positionState = singaporePositionState,
+            state = singaporeState,
             title = "Zoom in has been tapped $ticker times.",
             onClick = markerClick,
             draggable = true,
@@ -150,7 +151,7 @@ fun GoogleMapView(
             Text(it.title ?: "Title", color = Color.Red)
         }
         MarkerInfoWindowContent(
-            positionState = singapore2PositionState,
+            state = singapore2State,
             title = "Marker with custom info window.\nZoom in has been tapped $ticker times.",
             icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE),
             onClick = markerClick,
@@ -158,12 +159,12 @@ fun GoogleMapView(
             Text(it.title ?: "Title", color = Color.Blue)
         }
         Marker(
-            positionState = MarkerPositionState(position = singapore3),
+            state = singapore3State,
             title = "Marker in Singapore",
             onClick = markerClick
         )
         Circle(
-            center = circlePositionState,
+            center = circleCenter,
             fillColor = MaterialTheme.colors.secondary,
             strokeColor = MaterialTheme.colors.secondaryVariant,
             radius = 1000.0,
@@ -184,7 +185,8 @@ fun GoogleMapView(
             onClick = {
                 mapProperties = mapProperties.copy(mapType = MapType.NORMAL)
                 cameraPositionState.position = defaultCameraPosition
-                singaporePositionState.position = singapore
+                singaporeState.position = singapore
+                singaporeState.hideInfoWindow()
             }
         ) {
             Text(text = "RESET MAP", style = MaterialTheme.typography.body1)
@@ -219,7 +221,7 @@ fun GoogleMapView(
                 uiSettings = uiSettings.copy(zoomControlsEnabled = it)
             }
         )
-        DebugView(cameraPositionState, singaporePositionState)
+        DebugView(cameraPositionState, singaporeState)
     }
 }
 
@@ -298,7 +300,7 @@ private fun MapButton(text: String, onClick: () -> Unit) {
 @Composable
 private fun DebugView(
     cameraPositionState: CameraPositionState,
-    markerPositionState: MarkerPositionState
+    markerState: MarkerState
 ) {
     Column(
         Modifier
@@ -311,8 +313,8 @@ private fun DebugView(
         Text(text = "Camera position is ${cameraPositionState.position}")
         Spacer(modifier = Modifier.height(4.dp))
         val dragging =
-            if (markerPositionState.dragState == DragState.DRAG) "dragging" else "not dragging"
+            if (markerState.dragState == DragState.DRAG) "dragging" else "not dragging"
         Text(text = "Marker is $dragging")
-        Text(text = "Marker position is ${markerPositionState.position}")
+        Text(text = "Marker position is ${markerState.position}")
     }
 }

--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -158,7 +158,7 @@ fun GoogleMapView(
             Text(it.title ?: "Title", color = Color.Blue)
         }
         Marker(
-            position = singapore3,
+            positionState = MarkerPositionState(position = singapore3),
             title = "Marker in Singapore",
             onClick = markerClick
         )

--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -28,8 +28,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.Button
@@ -60,6 +62,7 @@ private const val TAG = "MapSampleActivity"
 val singapore = LatLng(1.35, 103.87)
 val singapore2 = LatLng(1.40, 103.77)
 val singapore3 = LatLng(1.45, 103.77)
+val defaultCameraPosition = CameraPosition.fromLatLngZoom(singapore, 11f)
 
 class MapSampleActivity : ComponentActivity() {
 
@@ -69,7 +72,7 @@ class MapSampleActivity : ComponentActivity() {
             var isMapLoaded by remember { mutableStateOf(false) }
             // Observing and controlling the camera's state can be done with a CameraPositionState
             val cameraPositionState = rememberCameraPositionState {
-                position = CameraPosition.fromLatLngZoom(singapore, 11f)
+                position = defaultCameraPosition
             }
 
             Box(Modifier.fillMaxSize()) {
@@ -106,6 +109,13 @@ fun GoogleMapView(
     cameraPositionState: CameraPositionState,
     onMapLoaded: () -> Unit,
 ) {
+    val singaporePositionState = rememberMarkerPositionState(position = singapore)
+    val singapore2PositionState = rememberMarkerPositionState(position = singapore2)
+    var circlePositionState by remember { mutableStateOf(singapore) }
+    if (singaporePositionState.dragState == DragState.END) {
+        circlePositionState = singaporePositionState.position
+    }
+
     var uiSettings by remember { mutableStateOf(MapUiSettings(compassEnabled = false)) }
     var shouldAnimateZoom by remember { mutableStateOf(true) }
     var ticker by remember { mutableStateOf(0) }
@@ -132,14 +142,15 @@ fun GoogleMapView(
             false
         }
         MarkerInfoWindowContent(
-            position = singapore,
+            positionState = singaporePositionState,
             title = "Zoom in has been tapped $ticker times.",
             onClick = markerClick,
+            draggable = true,
         ) {
             Text(it.title ?: "Title", color = Color.Red)
         }
         MarkerInfoWindowContent(
-            position = singapore2,
+            positionState = singapore2PositionState,
             title = "Marker with custom info window.\nZoom in has been tapped $ticker times.",
             icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE),
             onClick = markerClick,
@@ -152,7 +163,7 @@ fun GoogleMapView(
             onClick = markerClick
         )
         Circle(
-            center = singapore,
+            center = circlePositionState,
             fillColor = MaterialTheme.colors.secondary,
             strokeColor = MaterialTheme.colors.secondaryVariant,
             radius = 1000.0,
@@ -164,6 +175,20 @@ fun GoogleMapView(
             Log.d("GoogleMap", "Selected map type $it")
             mapProperties = mapProperties.copy(mapType = it)
         })
+        Button(
+            modifier = Modifier.padding(4.dp),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.colors.onPrimary,
+                contentColor = MaterialTheme.colors.primary
+            ),
+            onClick = {
+                mapProperties = mapProperties.copy(mapType = MapType.NORMAL)
+                cameraPositionState.position = defaultCameraPosition
+                singaporePositionState.position = singapore
+            }
+        ) {
+            Text(text = "RESET MAP", style = MaterialTheme.typography.body1)
+        }
         val coroutineScope = rememberCoroutineScope()
         ZoomControls(
             shouldAnimateZoom,
@@ -194,7 +219,7 @@ fun GoogleMapView(
                 uiSettings = uiSettings.copy(zoomControlsEnabled = it)
             }
         )
-        DebugView(cameraPositionState)
+        DebugView(cameraPositionState, singaporePositionState)
     }
 }
 
@@ -271,7 +296,10 @@ private fun MapButton(text: String, onClick: () -> Unit) {
 }
 
 @Composable
-private fun DebugView(cameraPositionState: CameraPositionState) {
+private fun DebugView(
+    cameraPositionState: CameraPositionState,
+    markerPositionState: MarkerPositionState
+) {
     Column(
         Modifier
             .fillMaxWidth(),
@@ -281,5 +309,10 @@ private fun DebugView(cameraPositionState: CameraPositionState) {
             if (cameraPositionState.isMoving) "moving" else "not moving"
         Text(text = "Camera is $moving")
         Text(text = "Camera position is ${cameraPositionState.position}")
+        Spacer(modifier = Modifier.height(4.dp))
+        val dragging =
+            if (markerPositionState.dragState == DragState.DRAG) "dragging" else "not dragging"
+        Text(text = "Marker is $dragging")
+        Text(text = "Marker position is ${markerPositionState.position}")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext.projectArtifactId = { project ->
 
 allprojects {
     group = 'com.google.maps.android'
-    version = '1.3.1'
+    version = '2.0.0-SNAPSHOT'
     project.ext.artifactId = rootProject.ext.projectArtifactId(project)
 }
 
@@ -125,8 +125,10 @@ subprojects { project ->
 
         repositories {
             maven {
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
                 name = "mavencentral"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                url = project.version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
                 credentials {
                     username sonatypeUsername
                     password sonatypePassword

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
@@ -112,22 +112,22 @@ internal class MapApplier(
         map.setOnMarkerDragListener(object : GoogleMap.OnMarkerDragListener {
             override fun onMarkerDrag(marker: Marker) {
                 with(decorations.nodeForMarker(marker)) {
-                    this?.markerPositionState?.position = marker.position
-                    this?.markerPositionState?.dragState = DragState.DRAG
+                    this?.markerState?.position = marker.position
+                    this?.markerState?.dragState = DragState.DRAG
                 }
             }
 
             override fun onMarkerDragEnd(marker: Marker) {
                 with(decorations.nodeForMarker(marker)) {
-                    this?.markerPositionState?.position = marker.position
-                    this?.markerPositionState?.dragState = DragState.END
+                    this?.markerState?.position = marker.position
+                    this?.markerState?.dragState = DragState.END
                 }
             }
 
             override fun onMarkerDragStart(marker: Marker) {
                 with(decorations.nodeForMarker(marker)) {
-                    this?.markerPositionState?.position = marker.position
-                    this?.markerPositionState?.dragState = DragState.START
+                    this?.markerState?.position = marker.position
+                    this?.markerState?.dragState = DragState.START
                 }
             }
         })

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
@@ -111,21 +111,24 @@ internal class MapApplier(
         }
         map.setOnMarkerDragListener(object : GoogleMap.OnMarkerDragListener {
             override fun onMarkerDrag(marker: Marker) {
-                val markerDragState =
-                    decorations.nodeForMarker(marker)?.markerDragState
-                markerDragState?.dragState = DragState.DRAG
+                with(decorations.nodeForMarker(marker)) {
+                    this?.markerPositionState?.position = marker.position
+                    this?.markerPositionState?.dragState = DragState.DRAG
+                }
             }
 
             override fun onMarkerDragEnd(marker: Marker) {
-                val markerDragState =
-                    decorations.nodeForMarker(marker)?.markerDragState
-                markerDragState?.dragState = DragState.END
+                with(decorations.nodeForMarker(marker)) {
+                    this?.markerPositionState?.position = marker.position
+                    this?.markerPositionState?.dragState = DragState.END
+                }
             }
 
             override fun onMarkerDragStart(marker: Marker) {
-                val markerDragState =
-                    decorations.nodeForMarker(marker)?.markerDragState
-                markerDragState?.dragState = DragState.START
+                with(decorations.nodeForMarker(marker)) {
+                    this?.markerPositionState?.position = marker.position
+                    this?.markerPositionState?.dragState = DragState.START
+                }
             }
         })
         map.setInfoWindowAdapter(


### PR DESCRIPTION
Merging 2.0 related changes into `main`. Marker (and siblings) now requires passing in a `MarkerState` to set its position and control its info window.

Changes:
* Enables observing marker drag events (#11)
* Enables showing/hiding info window (#69)

Closes #16 