### PR TITLE
docs: Add missing Javadocs for GoogleMap contentPadding parameter

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -66,6 +66,8 @@ import kotlinx.coroutines.awaitCancellation
  * @param onMyLocationButtonClick lambda invoked when the my location button is clicked
  * @param onMyLocationClick lambda invoked when the my location dot is clicked
  * @param onPOIClick lambda invoked when a POI is clicked
+ * @param contentPadding the padding values used to signal that portions of the map around the edges
+ * may be obscured. The map will move the Google logo, etc. to avoid overlapping the padding.
  * @param content the content of the map
  */
 @Composable


### PR DESCRIPTION
Someone on Discord asked about setting the padding on the `GoogleMap`, and I realized that we're missing Javadocs for this parameter.

This PR adds the missing Javadocs, based on:
https://developers.google.com/maps/documentation/android-sdk/reference/com/google/android/libraries/maps/GoogleMap#setPadding(int,%20int,%20int,%20int)

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)