### PR TITLE
chore: Use explicitApi.

### DIFF
--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -29,6 +29,7 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs += '-Xexplicit-api=strict'
     }
 }
 

--- a/maps-compose/src/androidTest/java/com/google/maps/android/compose/ExampleInstrumentedTest.kt
+++ b/maps-compose/src/androidTest/java/com/google/maps/android/compose/ExampleInstrumentedTest.kt
@@ -28,7 +28,7 @@ import org.junit.Assert.*
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class ExampleInstrumentedTest {
+internal class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -43,7 +43,7 @@ import kotlin.coroutines.resumeWithException
  * initial state.
  */
 @Composable
-inline fun rememberCameraPositionState(
+public inline fun rememberCameraPositionState(
     key: String? = null,
     crossinline init: CameraPositionState.() -> Unit = {}
 ): CameraPositionState = rememberSaveable(key = key, saver = CameraPositionState.Saver) {
@@ -57,21 +57,21 @@ inline fun rememberCameraPositionState(
  *
  * @param position the initial camera position
  */
-class CameraPositionState(
+public class CameraPositionState(
     position: CameraPosition = CameraPosition(LatLng(0.0, 0.0), 0f, 0f, 0f)
 ) {
     /**
      * Whether the camera is currently moving or not. This includes any kind of movement:
      * panning, zooming, or rotation.
      */
-    var isMoving by mutableStateOf(false)
+    public var isMoving: Boolean by mutableStateOf(false)
         internal set
 
     /**
      * Returns the current [Projection] to be used for converting between screen
      * coordinates and lat/lng.
      */
-    val projection: Projection?
+    public val projection: Projection?
         get() = map?.projection
 
     /**
@@ -85,7 +85,7 @@ class CameraPositionState(
     /**
      * Current position of the camera on the map.
      */
-    var position: CameraPosition
+    public var position: CameraPosition
         get() = rawPosition
         set(value) {
             synchronized(lock) {
@@ -181,7 +181,7 @@ class CameraPositionState(
      * strictly positive, otherwise an [IllegalArgumentException] will be thrown.
      */
     @UiThread
-    suspend fun animate(update: CameraUpdate, durationMs: Int = MAX_VALUE) {
+    public suspend fun animate(update: CameraUpdate, durationMs: Int = MAX_VALUE) {
         val myJob = currentCoroutineContext()[Job]
         try {
             suspendCancellableCoroutine<Unit> { continuation ->
@@ -276,7 +276,7 @@ class CameraPositionState(
      * This method must be called from the map's UI thread.
      */
     @UiThread
-    fun move(update: CameraUpdate) {
+    public fun move(update: CameraUpdate) {
         synchronized(lock) {
             val map = map
             movementOwner = null
@@ -289,11 +289,11 @@ class CameraPositionState(
         }
     }
 
-    companion object {
+    public companion object {
         /**
          * The default saver implementation for [CameraPositionState]
          */
-        val Saver = Saver<CameraPositionState, CameraPosition>(
+        public val Saver: Saver<CameraPositionState, CameraPosition> = Saver(
             save = { it.position },
             restore = { CameraPositionState(it) }
         )

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Circle.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Circle.kt
@@ -50,7 +50,7 @@ internal class CircleNode(
  * @param onClick a lambda invoked when the circle is clicked
  */
 @Composable
-fun Circle(
+public fun Circle(
     center: LatLng,
     clickable: Boolean = false,
     fillColor: Color = Color.Transparent,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -69,7 +69,7 @@ import kotlinx.coroutines.awaitCancellation
  * @param content the content of the map
  */
 @Composable
-fun GoogleMap(
+public fun GoogleMap(
     modifier: Modifier = Modifier,
     cameraPositionState: CameraPositionState = rememberCameraPositionState(),
     contentDescription: String? = null,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GroundOverlay.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GroundOverlay.kt
@@ -40,18 +40,18 @@ internal class GroundOverlayNode(
  *
  * Use one of the [create] methods to construct an instance of this class.
  */
-class GroundOverlayPosition private constructor(
-    val latLngBounds: LatLngBounds? = null,
-    val location: LatLng? = null,
-    val width: Float? = null,
-    val height: Float? = null,
+public class GroundOverlayPosition private constructor(
+    public val latLngBounds: LatLngBounds? = null,
+    public val location: LatLng? = null,
+    public val width: Float? = null,
+    public val height: Float? = null,
 ) {
-    companion object {
-        fun create(latLngBounds: LatLngBounds) : GroundOverlayPosition {
+    public companion object {
+        public fun create(latLngBounds: LatLngBounds) : GroundOverlayPosition {
             return GroundOverlayPosition(latLngBounds = latLngBounds)
         }
 
-        fun create(location: LatLng, width: Float, height: Float? = null) : GroundOverlayPosition {
+        public fun create(location: LatLng, width: Float, height: Float? = null) : GroundOverlayPosition {
             return GroundOverlayPosition(
                 location = location,
                 width = width,
@@ -76,7 +76,7 @@ class GroundOverlayPosition private constructor(
  * @param onClick a lambda invoked when the ground overlay is clicked
  */
 @Composable
-fun GroundOverlay(
+public fun GroundOverlay(
     position: GroundOverlayPosition,
     image: BitmapDescriptor,
     anchor: Offset = Offset(0.5f, 0.5f),

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapClickListeners.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapClickListeners.kt
@@ -26,22 +26,22 @@ import com.google.android.gms.maps.model.PointOfInterest
  * Default implementation of [IndoorStateChangeListener] with no-op
  * implementations.
  */
-object DefaultIndoorStateChangeListener : IndoorStateChangeListener
+public object DefaultIndoorStateChangeListener : IndoorStateChangeListener
 
 /**
  * Interface definition for building indoor level state changes.
  */
-interface IndoorStateChangeListener {
+public interface IndoorStateChangeListener {
     /**
      * Callback invoked when an indoor building comes to focus.
      */
-    fun onIndoorBuildingFocused() {}
+    public fun onIndoorBuildingFocused() {}
 
     /**
      * Callback invoked when a level for a building is activated.
      * @param building the activated building
      */
-    fun onIndoorLevelActivated(building: IndoorBuilding) {}
+    public fun onIndoorLevelActivated(building: IndoorBuilding) {}
 }
 
 /**

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapProperties.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapProperties.kt
@@ -27,16 +27,16 @@ internal val DefaultMapProperties = MapProperties()
  * compatibility on future changes.
  * See: https://jakewharton.com/public-api-challenges-in-kotlin/
  */
-class MapProperties(
-    val isBuildingEnabled: Boolean = false,
-    val isIndoorEnabled: Boolean = false,
-    val isMyLocationEnabled: Boolean = false,
-    val isTrafficEnabled: Boolean = false,
-    val latLngBoundsForCameraTarget: LatLngBounds? = null,
-    val mapStyleOptions: MapStyleOptions? = null,
-    val mapType: MapType = MapType.NORMAL,
-    val maxZoomPreference: Float = 21.0f,
-    val minZoomPreference: Float = 3.0f,
+public class MapProperties(
+    public val isBuildingEnabled: Boolean = false,
+    public val isIndoorEnabled: Boolean = false,
+    public val isMyLocationEnabled: Boolean = false,
+    public val isTrafficEnabled: Boolean = false,
+    public val latLngBoundsForCameraTarget: LatLngBounds? = null,
+    public val mapStyleOptions: MapStyleOptions? = null,
+    public val mapType: MapType = MapType.NORMAL,
+    public val maxZoomPreference: Float = 21.0f,
+    public val minZoomPreference: Float = 3.0f,
 ) {
     override fun toString(): String = "MapProperties(" +
         "isBuildingEnabled=$isBuildingEnabled, isIndoorEnabled=$isIndoorEnabled, " +
@@ -68,7 +68,7 @@ class MapProperties(
         minZoomPreference
     )
 
-    fun copy(
+    public fun copy(
         isBuildingEnabled: Boolean = this.isBuildingEnabled,
         isIndoorEnabled: Boolean = this.isIndoorEnabled,
         isMyLocationEnabled: Boolean = this.isMyLocationEnabled,
@@ -78,7 +78,7 @@ class MapProperties(
         mapType: MapType = this.mapType,
         maxZoomPreference: Float = this.maxZoomPreference,
         minZoomPreference: Float = this.minZoomPreference,
-    ) = MapProperties(
+    ): MapProperties = MapProperties(
         isBuildingEnabled = isBuildingEnabled,
         isIndoorEnabled = isIndoorEnabled,
         isMyLocationEnabled = isMyLocationEnabled,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapType.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapType.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.Immutable
  * Enumerates the different types of map tiles.
  */
 @Immutable
-enum class MapType(val value: Int) {
+public enum class MapType(public val value: Int) {
     NONE(com.google.android.gms.maps.GoogleMap.MAP_TYPE_NONE),
     NORMAL(com.google.android.gms.maps.GoogleMap.MAP_TYPE_NORMAL),
     SATELLITE(com.google.android.gms.maps.GoogleMap.MAP_TYPE_SATELLITE),

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapUiSettings.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapUiSettings.kt
@@ -25,17 +25,17 @@ internal val DefaultMapUiSettings = MapUiSettings()
  * compatibility on future changes.
  * See: https://jakewharton.com/public-api-challenges-in-kotlin/
  */
-class MapUiSettings(
-    val compassEnabled: Boolean = true,
-    val indoorLevelPickerEnabled: Boolean = true,
-    val mapToolbarEnabled: Boolean = true,
-    val myLocationButtonEnabled: Boolean = true,
-    val rotationGesturesEnabled: Boolean = true,
-    val scrollGesturesEnabled: Boolean = true,
-    val scrollGesturesEnabledDuringRotateOrZoom: Boolean = true,
-    val tiltGesturesEnabled: Boolean = true,
-    val zoomControlsEnabled: Boolean = true,
-    val zoomGesturesEnabled: Boolean = true,
+public class MapUiSettings(
+    public val compassEnabled: Boolean = true,
+    public val indoorLevelPickerEnabled: Boolean = true,
+    public val mapToolbarEnabled: Boolean = true,
+    public val myLocationButtonEnabled: Boolean = true,
+    public val rotationGesturesEnabled: Boolean = true,
+    public val scrollGesturesEnabled: Boolean = true,
+    public val scrollGesturesEnabledDuringRotateOrZoom: Boolean = true,
+    public val tiltGesturesEnabled: Boolean = true,
+    public val zoomControlsEnabled: Boolean = true,
+    public val zoomGesturesEnabled: Boolean = true,
 ) {
     override fun toString(): String = "MapUiSettings(" +
         "compassEnabled=$compassEnabled, indoorLevelPickerEnabled=$indoorLevelPickerEnabled, " +
@@ -70,7 +70,7 @@ class MapUiSettings(
         zoomGesturesEnabled
     )
 
-    fun copy(
+    public fun copy(
         compassEnabled: Boolean = this.compassEnabled,
         indoorLevelPickerEnabled: Boolean = this.indoorLevelPickerEnabled,
         mapToolbarEnabled: Boolean = this.mapToolbarEnabled,
@@ -81,7 +81,7 @@ class MapUiSettings(
         tiltGesturesEnabled: Boolean = this.tiltGesturesEnabled,
         zoomControlsEnabled: Boolean = this.zoomControlsEnabled,
         zoomGesturesEnabled: Boolean = this.zoomGesturesEnabled
-    ) = MapUiSettings(
+    ): MapUiSettings = MapUiSettings(
         compassEnabled = compassEnabled,
         indoorLevelPickerEnabled = indoorLevelPickerEnabled,
         mapToolbarEnabled = mapToolbarEnabled,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -52,7 +52,7 @@ internal class MarkerNode(
 }
 
 @Immutable
-enum class DragState {
+public enum class DragState {
     START, DRAG, END
 }
 
@@ -61,18 +61,18 @@ enum class DragState {
  *
  * @param position the initial marker position
  */
-class MarkerState(
+public class MarkerState(
     position: LatLng = LatLng(0.0, 0.0)
 ) {
     /**
      * Current position of the marker.
      */
-    var position: LatLng by mutableStateOf(position)
+    public var position: LatLng by mutableStateOf(position)
 
     /**
      * Current [DragState] of the marker.
      */
-    var dragState: DragState by mutableStateOf(DragState.END)
+    public var dragState: DragState by mutableStateOf(DragState.END)
         internal set
 
     // The marker associated with this MarkerState.
@@ -88,22 +88,22 @@ class MarkerState(
     /**
      * Shows the info window for the underlying marker
      */
-    fun showInfoWindow() {
+    public fun showInfoWindow() {
         marker?.showInfoWindow()
     }
 
     /**
      * Hides the info window for the underlying marker
      */
-    fun hideInfoWindow() {
+    public fun hideInfoWindow() {
         marker?.hideInfoWindow()
     }
 
-    companion object {
+    public companion object {
         /**
          * The default saver implementation for [MarkerState]
          */
-        val Saver = Saver<MarkerState, LatLng>(
+        public val Saver: Saver<MarkerState, LatLng> = Saver(
             save = { it.position },
             restore = { MarkerState(it) }
         )
@@ -111,7 +111,7 @@ class MarkerState(
 }
 
 @Composable
-fun rememberMarkerState(
+public fun rememberMarkerState(
     key: String? = null,
     position: LatLng = LatLng(0.0, 0.0)
 ): MarkerState = rememberSaveable(key = key, saver = MarkerState.Saver) {
@@ -141,7 +141,7 @@ fun rememberMarkerState(
  * @param onInfoWindowLongClick a lambda invoked when the marker's info window is long clicked
  */
 @Composable
-fun Marker(
+public fun Marker(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
@@ -208,7 +208,7 @@ fun Marker(
  * info window's content
  */
 @Composable
-fun MarkerInfoWindow(
+public fun MarkerInfoWindow(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
@@ -277,7 +277,7 @@ fun MarkerInfoWindow(
  * info window's content
  */
 @Composable
-fun MarkerInfoWindowContent(
+public fun MarkerInfoWindowContent(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Polygon.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Polygon.kt
@@ -52,7 +52,7 @@ internal class PolygonNode(
  * @param onClick a lambda invoked when the polygon is clicked
  */
 @Composable
-fun Polygon(
+public fun Polygon(
     points: List<LatLng>,
     clickable: Boolean = false,
     fillColor: Color = Color.Black,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Polyline.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Polyline.kt
@@ -54,7 +54,7 @@ internal class PolylineNode(
  * @param onClick a lambda invoked when the polyline is clicked
  */
 @Composable
-fun Polyline(
+public fun Polyline(
     points: List<LatLng>,
     clickable: Boolean = false,
     color: Color = Color.Black,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/TileOverlay.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/TileOverlay.kt
@@ -41,7 +41,7 @@ private class TileOverlayNode(
  * @param onClick a lambda invoked when the tile overlay is clicked
  */
 @Composable
-fun TileOverlay(
+public fun TileOverlay(
     tileProvider: TileProvider,
     fadeIn: Boolean = true,
     transparency: Float = 0f,


### PR DESCRIPTION
Use Kotlin's `explicitApi` to encourage explicitly adding a visibility modifier to prevent leaking internal classes.
