### PR TITLE
docs: Add compose version requirement to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
     
     // Also include Compose version `1.2.0-alpha03` or higher - for example:
-     implementation "androidx.compose.foundation:foundation:1.2.0-alpha03"
+    implementation "androidx.compose.foundation:foundation:1.2.0-alpha03"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ dependencies {
     
     // Make sure to also include the latest version of the Maps SDK for Android 
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
+    
+    // Also include Compose version `1.2.0-alpha03` or higher - for example:
+     implementation "androidx.compose.foundation:foundation:1.2.0-alpha03"
 }
 ```
 


### PR DESCRIPTION
Users are installing older version of Compose and hitting problems - see:
* https://github.com/googlemaps/android-maps-compose/issues/67#issuecomment-1107847164
* https://discordapp.com/channels/676948200904589322/939194796138975263/966366331492524102

This change makes it clearer in the installation instructions what the current base Compose requirement is without needing to look through the release notes.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)