### PR TITLE
fix: Ensure CameraPositionState map reference clears when GoogleMap leaves composition.

### DIFF
--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -208,6 +208,14 @@ class GoogleMapViewTests {
         assertTrue(mapLoaded)
     }
 
+    @Test
+    fun testCameraPositionStateMapClears() {
+        // TODO(Complete)
+//        composeTestRule.setContent {
+//        }
+//        assertTrue(cameraPositionState.map)
+    }
+
     private fun zoom(
         shouldAnimate: Boolean,
         zoomIn: Boolean,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
@@ -26,6 +26,7 @@ import com.google.android.gms.maps.model.Polyline
 internal interface MapNode {
     fun onAttached() {}
     fun onRemoved() {}
+    fun onCleared() {}
 }
 
 private object MapNodeRoot : MapNode
@@ -43,6 +44,8 @@ internal class MapApplier(
 
     override fun onClear() {
         map.clear()
+        decorations.forEach { it.onCleared() }
+        decorations.clear()
     }
 
     override fun insertBottomUp(index: Int, instance: MapNode) {


### PR DESCRIPTION
Fixes the issue where the `CameraPositionState` maintains a reference to a `GoogleMap` when it is hoisted. The previous implementation did not appropriately clean up after the `GoogleMap` composable leaves the composition.

TODO:
- [ ] Write unit test

Fixes #106 🦕