### PR TITLE
fix: Ensure CameraPositionState map reference clears when GoogleMap l…

### DIFF
--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -15,13 +15,13 @@
 package com.google.maps.android.compose
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.annotation.UiThreadTest
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import org.junit.Assert.assertEquals
@@ -44,15 +44,7 @@ class GoogleMapViewTests {
 
     private lateinit var cameraPositionState: CameraPositionState
 
-    @Before
-    fun setUp() {
-        cameraPositionState = CameraPositionState(
-            position = CameraPosition.fromLatLngZoom(
-                startingPosition,
-                startingZoom
-            )
-        )
-
+    private fun initMap(content: @Composable () -> Unit = {}) {
         val countDownLatch = CountDownLatch(1)
         composeTestRule.setContent {
             GoogleMapView(
@@ -61,19 +53,33 @@ class GoogleMapViewTests {
                 onMapLoaded = {
                     countDownLatch.countDown()
                 }
-            )
+            ) {
+                content.invoke()
+            }
         }
         val mapLoaded = countDownLatch.await(30, TimeUnit.SECONDS)
         assertTrue("Map loaded", mapLoaded)
     }
 
+    @Before
+    fun setUp() {
+        cameraPositionState = CameraPositionState(
+            position = CameraPosition.fromLatLngZoom(
+                startingPosition,
+                startingZoom
+            )
+        )
+    }
+
     @Test
     fun testStartingCameraPosition() {
+        initMap()
         startingPosition.assertEquals(cameraPositionState.position.target)
     }
 
     @Test
     fun testCameraReportsMoving() {
+        initMap()
         zoom(shouldAnimate = true, zoomIn = true) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
@@ -84,6 +90,7 @@ class GoogleMapViewTests {
 
     @Test
     fun testCameraReportsNotMoving() {
+        initMap()
         zoom(shouldAnimate = true, zoomIn = true) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
@@ -97,6 +104,7 @@ class GoogleMapViewTests {
 
     @Test
     fun testCameraZoomInAnimation() {
+        initMap()
         zoom(shouldAnimate = true, zoomIn = true) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
@@ -114,6 +122,7 @@ class GoogleMapViewTests {
 
     @Test
     fun testCameraZoomIn() {
+        initMap()
         zoom(shouldAnimate = false, zoomIn = true) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
@@ -131,6 +140,7 @@ class GoogleMapViewTests {
 
     @Test
     fun testCameraZoomOut() {
+        initMap()
         zoom(shouldAnimate = false, zoomIn = false) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
@@ -148,6 +158,7 @@ class GoogleMapViewTests {
 
     @Test
     fun testCameraZoomOutAnimation() {
+        initMap()
         zoom(shouldAnimate = true, zoomIn = false) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
@@ -164,56 +175,49 @@ class GoogleMapViewTests {
     }
 
     @Test
-    @UiThreadTest
     fun testLatLngInVisibleRegion() {
-        val projection = cameraPositionState.projection
-        assertNotNull(projection)
-        assertTrue(
-            projection!!.visibleRegion.latLngBounds.contains(startingPosition)
-        )
+        initMap()
+        composeTestRule.runOnUiThread {
+            val projection = cameraPositionState.projection
+            assertNotNull(projection)
+            assertTrue(
+                projection!!.visibleRegion.latLngBounds.contains(startingPosition)
+            )
+        }
     }
 
     @Test
-    @UiThreadTest
     fun testLatLngNotInVisibleRegion() {
-        val projection = cameraPositionState.projection
-        assertNotNull(projection)
-        val latLng = LatLng(23.4, 25.6)
-        assertFalse(
-            projection!!.visibleRegion.latLngBounds.contains(latLng)
-        )
+        initMap()
+        composeTestRule.runOnUiThread {
+            val projection = cameraPositionState.projection
+            assertNotNull(projection)
+            val latLng = LatLng(23.4, 25.6)
+            assertFalse(
+                projection!!.visibleRegion.latLngBounds.contains(latLng)
+            )
+        }
     }
 
     @Test(expected = IllegalStateException::class)
     fun testMarkerStateCannotBeReused() {
-        val countDownLatch = CountDownLatch(1)
-        composeTestRule.setContent {
-            GoogleMap(
-                modifier = Modifier.fillMaxSize(),
-                cameraPositionState = cameraPositionState,
-                onMapLoaded = {
-                    countDownLatch.countDown()
-                }
-            ) {
-                val markerState = rememberMarkerState()
-                Marker(
-                    state = markerState
-                )
-                Marker(
-                    state = markerState
-                )
-            }
+        initMap {
+            val markerState = rememberMarkerState()
+            Marker(
+                state = markerState
+            )
+            Marker(
+                state = markerState
+            )
         }
-        val mapLoaded = countDownLatch.await(30, TimeUnit.SECONDS)
-        assertTrue(mapLoaded)
     }
 
     @Test
     fun testCameraPositionStateMapClears() {
-        // TODO(Complete)
-//        composeTestRule.setContent {
-//        }
-//        assertTrue(cameraPositionState.map)
+        initMap()
+        composeTestRule.onNodeWithTag("toggleMapVisibility")
+            .performClick()
+            .performClick()
     }
 
     private fun zoom(

--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -208,6 +208,14 @@ class GoogleMapViewTests {
         assertTrue(mapLoaded)
     }
 
+    @Test
+    fun testCameraPositionStateMapClears() {
+        // TODO(Complete)
+//        composeTestRule.setContent {
+//        }
+//        assertTrue(cameraPositionState.map)
+    }
+
     private fun zoom(
         shouldAnimate: Boolean,
         zoomIn: Boolean,

--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -181,25 +181,21 @@ fun GoogleMapView(
             Log.d("GoogleMap", "Selected map type $it")
             mapProperties = mapProperties.copy(mapType = it)
         })
-        Button(
-            modifier = Modifier.padding(4.dp),
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.colors.onPrimary,
-                contentColor = MaterialTheme.colors.primary
-            ),
-            onClick = {
-                mapProperties = mapProperties.copy(mapType = MapType.NORMAL)
-                cameraPositionState.position = defaultCameraPosition
-                singaporeState.position = singapore
-                singaporeState.hideInfoWindow()
-            }
-        ) {
-            Text(text = "RESET MAP", style = MaterialTheme.typography.body1)
-        }
-        Button(
-            modifier = Modifier.testTag("toggleMapVisibility"),
-            onClick = { mapVisible = !mapVisible }) {
-            Text(text = "Toggle Map")
+        Row {
+            MapButton(
+                text = "Reset Map",
+                onClick = {
+                    mapProperties = mapProperties.copy(mapType = MapType.NORMAL)
+                    cameraPositionState.position = defaultCameraPosition
+                    singaporeState.position = singapore
+                    singaporeState.hideInfoWindow()
+                }
+            )
+            MapButton(
+                text = "Toggle Map",
+                onClick = { mapVisible = !mapVisible },
+                modifier = Modifier.testTag("toggleMapVisibility"),
+            )
         }
         val coroutineScope = rememberCoroutineScope()
         ZoomControls(
@@ -252,18 +248,8 @@ private fun MapTypeControls(
 }
 
 @Composable
-private fun MapTypeButton(type: MapType, onClick: () -> Unit) {
-    Button(
-        modifier = Modifier.padding(4.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = MaterialTheme.colors.onPrimary,
-            contentColor = MaterialTheme.colors.primary
-        ),
-        onClick = onClick
-    ) {
-        Text(text = type.toString(), style = MaterialTheme.typography.body1)
-    }
-}
+private fun MapTypeButton(type: MapType, onClick: () -> Unit) =
+    MapButton(text = type.toString(), onClick = onClick)
 
 @Composable
 private fun ZoomControls(
@@ -294,16 +280,16 @@ private fun ZoomControls(
 }
 
 @Composable
-private fun MapButton(text: String, onClick: () -> Unit) {
+private fun MapButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Button(
-        modifier = Modifier.padding(8.dp),
+        modifier = modifier.padding(4.dp),
         colors = ButtonDefaults.buttonColors(
             backgroundColor = MaterialTheme.colors.onPrimary,
             contentColor = MaterialTheme.colors.primary
         ),
         onClick = onClick
     ) {
-        Text(text = text, style = MaterialTheme.typography.h5)
+        Text(text = text, style = MaterialTheme.typography.body1)
     }
 }
 

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -104,7 +104,7 @@ class CameraPositionState(
 
     // The map currently associated with this CameraPositionState.
     // Guarded by `lock`.
-    private var map: GoogleMap? = null
+    var map: GoogleMap? = null
 
     // An action to run when the map becomes available or unavailable.
     // represents a mutually exclusive mutation to perform while holding `lock`.

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -104,7 +104,7 @@ class CameraPositionState(
 
     // The map currently associated with this CameraPositionState.
     // Guarded by `lock`.
-    var map: GoogleMap? = null
+    private var map: GoogleMap? = null
 
     // An action to run when the map becomes available or unavailable.
     // represents a mutually exclusive mutation to perform while holding `lock`.

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
@@ -26,6 +26,7 @@ import com.google.android.gms.maps.model.Polyline
 internal interface MapNode {
     fun onAttached() {}
     fun onRemoved() {}
+    fun onCleared() {}
 }
 
 private object MapNodeRoot : MapNode
@@ -43,6 +44,8 @@ internal class MapApplier(
 
     override fun onClear() {
         map.clear()
+        decorations.forEach { it.onCleared() }
+        decorations.clear()
     }
 
     override fun insertBottomUp(index: Int, instance: MapNode) {

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
@@ -94,6 +94,10 @@ internal class MapPropertiesNode(
     override fun onRemoved() {
         cameraPositionState.setMap(null)
     }
+
+    override fun onCleared() {
+        cameraPositionState.setMap(null)
+    }
 }
 
 internal val NoPadding = PaddingValues()

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -49,6 +49,11 @@ internal class MarkerNode(
         markerState.marker = null
         marker.remove()
     }
+
+    override fun onCleared() {
+        markerState.marker = null
+        marker.remove()
+    }
 }
 
 @Immutable


### PR DESCRIPTION
Fixes the issue where the `CameraPositionState` maintains a reference to a `GoogleMap` when it is hoisted. The previous implementation did not appropriately clean up after the `GoogleMap` composable leaves the composition.

TODO:
- [x] Write unit test

Fixes #106 🦕
