### PR TITLE
chore: Add GoogleMapComposable annotation.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     // the maven declaration of Maps Compose can be used as a snippet.
     // implementation project(':maps-compose')
     // [END_EXCLUDE]
-    implementation  "com.google.maps.android:maps-compose:2.1.1"
+    implementation  "com.google.maps.android:maps-compose:2.2.0"
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
 }
 // [END maps_android_compose_dependency]

--- a/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt
@@ -108,7 +108,7 @@ fun GoogleMapView(
     modifier: Modifier,
     cameraPositionState: CameraPositionState,
     onMapLoaded: () -> Unit,
-    content: @Composable () -> Unit = {}
+    content: @Composable @GoogleMapComposable () -> Unit = {}
 ) {
     val singaporeState = rememberMarkerState(position = singapore)
     val singapore2State = rememberMarkerState(position = singapore2)

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Circle.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Circle.kt
@@ -50,6 +50,7 @@ internal class CircleNode(
  * @param onClick a lambda invoked when the circle is clicked
  */
 @Composable
+@GoogleMapComposable
 public fun Circle(
     center: LatLng,
     clickable: Boolean = false,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -87,7 +87,7 @@ public fun GoogleMap(
     onMyLocationClick: (Location) -> Unit = {},
     onPOIClick: (PointOfInterest) -> Unit = {},
     contentPadding: PaddingValues = NoPadding,
-    content: (@Composable () -> Unit)? = null,
+    content: (@Composable @GoogleMapComposable () -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val mapView = remember { MapView(context, googleMapOptionsFactory()) }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMapComposable.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMapComposable.kt
@@ -1,0 +1,18 @@
+package com.google.maps.android.compose
+
+import androidx.compose.runtime.ComposableTargetMarker
+
+/**
+ * An annotation that can be used to mark a composable function as being expected to be use in a
+ * composable function that is also marked or inferred to be marked as a [GoogleMapComposable].
+ */
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "Google Map Composable")
+@Target(
+    AnnotationTarget.FILE,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.TYPE,
+    AnnotationTarget.TYPE_PARAMETER,
+)
+public annotation class GoogleMapComposable

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GroundOverlay.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GroundOverlay.kt
@@ -76,6 +76,7 @@ public class GroundOverlayPosition private constructor(
  * @param onClick a lambda invoked when the ground overlay is clicked
  */
 @Composable
+@GoogleMapComposable
 public fun GroundOverlay(
     position: GroundOverlayPosition,
     image: BitmapDescriptor,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -146,6 +146,7 @@ public fun rememberMarkerState(
  * @param onInfoWindowLongClick a lambda invoked when the marker's info window is long clicked
  */
 @Composable
+@GoogleMapComposable
 public fun Marker(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,
@@ -213,6 +214,7 @@ public fun Marker(
  * info window's content
  */
 @Composable
+@GoogleMapComposable
 public fun MarkerInfoWindow(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,
@@ -282,6 +284,7 @@ public fun MarkerInfoWindow(
  * info window's content
  */
 @Composable
+@GoogleMapComposable
 public fun MarkerInfoWindowContent(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,
@@ -352,6 +355,7 @@ public fun MarkerInfoWindowContent(
  * the info window's content. If this value is non-null, [infoWindow] must be null.
  */
 @Composable
+@GoogleMapComposable
 private fun MarkerImpl(
     state: MarkerState = rememberMarkerState(),
     alpha: Float = 1.0f,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Polygon.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Polygon.kt
@@ -52,6 +52,7 @@ internal class PolygonNode(
  * @param onClick a lambda invoked when the polygon is clicked
  */
 @Composable
+@GoogleMapComposable
 public fun Polygon(
     points: List<LatLng>,
     clickable: Boolean = false,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Polyline.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Polyline.kt
@@ -54,6 +54,7 @@ internal class PolylineNode(
  * @param onClick a lambda invoked when the polyline is clicked
  */
 @Composable
+@GoogleMapComposable
 public fun Polyline(
     points: List<LatLng>,
     clickable: Boolean = false,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/TileOverlay.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/TileOverlay.kt
@@ -41,6 +41,7 @@ private class TileOverlayNode(
  * @param onClick a lambda invoked when the tile overlay is clicked
  */
 @Composable
+@GoogleMapComposable
 public fun TileOverlay(
     tileProvider: TileProvider,
     fadeIn: Boolean = true,


### PR DESCRIPTION
Add `GoogleMapComposable` annotation, and use across Maps Compose composable functions, to produce build warnings when these are used outside of the `GoogleMap` content lambda. Similarly, a warning is shown when non-Maps Compose composables are used within the `GoogleMap` content lambda.

Example:
````
w: /Users/chris/workspace/android-maps-compose/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt: (78, 13): A UI Composable composable parameter was provided where a Google Map Composable composable was expected
w: /Users/chris/workspace/android-maps-compose/app/src/main/java/com/google/maps/android/compose/MapSampleActivity.kt: (80, 17): Calling a Google Map Composable composable function where a UI Composable composable was expecte
```