### PR TITLE
docs: Add LocationTrackingActivity to example app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,9 +62,9 @@ dependencies {
     // module.
     // However, this should remain uncommented on the `main` branch so that
     // the maven declaration of Maps Compose can be used as a snippet.
-    // implementation project(':maps-compose')
+    implementation project(':maps-compose')
     // [END_EXCLUDE]
-    implementation  "com.google.maps.android:maps-compose:2.2.1"
+    //implementation  "com.google.maps.android:maps-compose:2.2.1"
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
 }
 // [END maps_android_compose_dependency]

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,10 +42,13 @@
     </activity>
     <activity
         android:name=".BasicMapActivity"
-        android:exported="true" />
+        android:exported="false" />
     <activity
         android:name=".MapInColumnActivity"
-        android:exported="true"/>
+        android:exported="false"/>
+    <activity
+        android:name=".LocationTrackingActivity"
+        android:exported="false"/>
 
     <!-- Used by createComponentActivity() for unit testing -->
     <activity android:name="androidx.activity.ComponentActivity" />

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -34,7 +34,8 @@ private val singapore = LatLng(1.35, 103.87)
 private val defaultCameraPosition = CameraPosition.fromLatLngZoom(singapore, zoom)
 
 /**
- * This shows how to use a custom location source.
+ * This shows how to use a custom location source to show a blue dot on the map based on your own
+ * locations.
  */
 class LocationTrackingActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -42,6 +42,7 @@ class LocationTrackingActivity : AppCompatActivity() {
     private var counter = 0
     private lateinit var lastLocation: Location
 
+    // A "fake" location provider that generates random locations every 2 seconds
     private val locationFlow = callbackFlow {
         while (true) {
             delay(2_000)

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -43,6 +43,8 @@ class LocationTrackingActivity : AppCompatActivity() {
     private lateinit var lastLocation: Location
 
     // A "fake" location provider that generates random locations every 2 seconds
+    // Normally you'd request location updates:
+    // https://developer.android.com/training/location/request-updates
     private val locationFlow = callbackFlow {
         while (true) {
             delay(2_000)
@@ -62,15 +64,16 @@ class LocationTrackingActivity : AppCompatActivity() {
 
         setContent {
             var isMapLoaded by remember { mutableStateOf(false) }
+
             // To control the map camera
             val cameraPositionState = rememberCameraPositionState {
                 position = defaultCameraPosition
             }
+
             // To show blue dot on map
             val mapProperties by remember { mutableStateOf(MapProperties(isMyLocationEnabled = true)) }
 
-            // Collect location updates - normally you'd request location updates
-            // https://developer.android.com/training/location/request-updates
+            // Collect location updates
             val locationState = locationFlow.collectAsState(initial = newLocation())
 
             // Update blue dot and camera when the location changes
@@ -84,14 +87,14 @@ class LocationTrackingActivity : AppCompatActivity() {
             }
 
             Box(Modifier.fillMaxSize()) {
-                GoogleMapViewTracking(
+                GoogleMap(
                     modifier = Modifier.matchParentSize(),
                     cameraPositionState = cameraPositionState,
                     onMapLoaded = {
                         isMapLoaded = true
                     },
                     locationSource = locationSource,
-                    mapProperties = mapProperties
+                    properties = mapProperties
                 )
                 if (!isMapLoaded) {
                     AnimatedVisibility(
@@ -109,30 +112,6 @@ class LocationTrackingActivity : AppCompatActivity() {
                     }
                 }
             }
-        }
-    }
-}
-
-@Composable
-fun GoogleMapViewTracking(
-    modifier: Modifier,
-    cameraPositionState: CameraPositionState,
-    onMapLoaded: () -> Unit,
-    locationSource: LocationSource,
-    mapProperties: MapProperties,
-    content: @Composable () -> Unit = {}
-) {
-    var mapVisible by remember { mutableStateOf(true) }
-
-    if (mapVisible) {
-        GoogleMap(
-            modifier = modifier,
-            cameraPositionState = cameraPositionState,
-            onMapLoaded = onMapLoaded,
-            locationSource = locationSource,
-            properties = mapProperties
-        ) {
-            content()
         }
     }
 }

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -42,16 +42,16 @@ class LocationTrackingActivity : AppCompatActivity() {
     private val locationSource = MyLocationSource()
     private var counter = 0
 
-    // Generates "fake" locations randomly every 2 seconds. 
+    // Generates "fake" locations randomly every 2 seconds.
     // Normally you'd request location updates:
     // https://developer.android.com/training/location/request-updates
     private val locationFlow = callbackFlow {
         while (true) {
             ++counter
 
-            val lastLocation = newLocation()
-            Log.d(TAG, "Location $counter: $lastLocation")
-            trySend(lastLocation)
+            val location = newLocation()
+            Log.d(TAG, "Location $counter: $location")
+            trySend(location)
 
             delay(2_000)
         }

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -61,9 +61,12 @@ class LocationTrackingActivity : AppCompatActivity() {
 
         setContent {
             var isMapLoaded by remember { mutableStateOf(false) }
+            // To control the map camera
             val cameraPositionState = rememberCameraPositionState {
                 position = defaultCameraPosition
             }
+            // To show blue dot on map
+            val mapProperties by remember { mutableStateOf(MapProperties(isMyLocationEnabled = true)) }
 
             // Collect location updates - normally you'd request location updates
             // https://developer.android.com/training/location/request-updates
@@ -86,7 +89,8 @@ class LocationTrackingActivity : AppCompatActivity() {
                     onMapLoaded = {
                         isMapLoaded = true
                     },
-                    locationSource = locationSource
+                    locationSource = locationSource,
+                    mapProperties = mapProperties
                 )
                 if (!isMapLoaded) {
                     AnimatedVisibility(
@@ -114,6 +118,7 @@ fun GoogleMapViewTracking(
     cameraPositionState: CameraPositionState,
     onMapLoaded: () -> Unit,
     locationSource: LocationSource,
+    mapProperties: MapProperties,
     content: @Composable () -> Unit = {}
 ) {
     var mapVisible by remember { mutableStateOf(true) }
@@ -123,7 +128,8 @@ fun GoogleMapViewTracking(
             modifier = modifier,
             cameraPositionState = cameraPositionState,
             onMapLoaded = onMapLoaded,
-            locationSource = locationSource
+            locationSource = locationSource,
+            properties = mapProperties
         ) {
             content()
         }

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -41,18 +41,19 @@ class LocationTrackingActivity : AppCompatActivity() {
 
     private val locationSource = MyLocationSource()
     private var counter = 0
-    private lateinit var lastLocation: Location
 
-    // A "fake" location provider that generates random locations every 2 seconds
+    // Generates "fake" locations randomly every 2 seconds. 
     // Normally you'd request location updates:
     // https://developer.android.com/training/location/request-updates
     private val locationFlow = callbackFlow {
         while (true) {
-            delay(2_000)
             ++counter
-            lastLocation = newLocation()
+
+            val lastLocation = newLocation()
             Log.d(TAG, "Location $counter: $lastLocation")
             trySend(lastLocation)
+
+            delay(2_000)
         }
     }.shareIn(
         lifecycleScope,

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -1,0 +1,161 @@
+package com.google.maps.android.compose
+
+import android.location.Location
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.LocationSource
+import com.google.android.gms.maps.LocationSource.OnLocationChangedListener
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.shareIn
+import kotlin.random.Random
+
+private const val TAG = "LocationTrackActivity"
+private const val zoom = 8f
+private val singapore = LatLng(1.35, 103.87)
+private val defaultCameraPosition = CameraPosition.fromLatLngZoom(singapore, zoom)
+
+/**
+ * This shows how to use a custom location source.
+ */
+class LocationTrackingActivity : AppCompatActivity() {
+
+    private val locationSource = MyLocationSource()
+    private var counter = 0
+    private lateinit var lastLocation: Location
+
+    private val locationFlow = callbackFlow {
+        while (true) {
+            delay(2_000)
+            ++counter
+            lastLocation = newLocation()
+            Log.d(TAG, "Location $counter: $lastLocation")
+            trySend(lastLocation)
+        }
+    }.shareIn(
+        lifecycleScope,
+        replay = 0,
+        started = SharingStarted.WhileSubscribed()
+    )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            var isMapLoaded by remember { mutableStateOf(false) }
+            val cameraPositionState = rememberCameraPositionState {
+                position = defaultCameraPosition
+            }
+
+            // Collect location updates - normally you'd request location updates
+            // https://developer.android.com/training/location/request-updates
+            val locationState = locationFlow.collectAsState(initial = newLocation())
+
+            // Update blue dot and camera when the location changes
+            LaunchedEffect(locationState.value) {
+                Log.d(TAG, "Updating blue dot on map...")
+                locationSource.onLocationChanged(locationState.value)
+
+                Log.d(TAG, "Updating camera position...")
+                val cameraPosition = CameraPosition.fromLatLngZoom(LatLng(locationState.value.latitude, locationState.value.longitude), zoom)
+                cameraPositionState.animate(CameraUpdateFactory.newCameraPosition(cameraPosition), 1_000)
+            }
+
+            Box(Modifier.fillMaxSize()) {
+                GoogleMapViewTracking(
+                    modifier = Modifier.matchParentSize(),
+                    cameraPositionState = cameraPositionState,
+                    onMapLoaded = {
+                        isMapLoaded = true
+                    },
+                    locationSource = locationSource
+                )
+                if (!isMapLoaded) {
+                    AnimatedVisibility(
+                        modifier = Modifier
+                            .matchParentSize(),
+                        visible = !isMapLoaded,
+                        enter = EnterTransition.None,
+                        exit = fadeOut()
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .background(MaterialTheme.colors.background)
+                                .wrapContentSize()
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun GoogleMapViewTracking(
+    modifier: Modifier,
+    cameraPositionState: CameraPositionState,
+    onMapLoaded: () -> Unit,
+    locationSource: LocationSource,
+    content: @Composable () -> Unit = {}
+) {
+    var mapVisible by remember { mutableStateOf(true) }
+
+    if (mapVisible) {
+        GoogleMap(
+            modifier = modifier,
+            cameraPositionState = cameraPositionState,
+            onMapLoaded = onMapLoaded,
+            locationSource = locationSource
+        ) {
+            content()
+        }
+    }
+}
+
+/**
+ * A [LocationSource] which allows it's location to be set. In practice you would request location
+ * updates (https://developer.android.com/training/location/request-updates).
+ */
+private class MyLocationSource : LocationSource {
+
+    private var listener: OnLocationChangedListener? = null
+
+    override fun activate(listener: OnLocationChangedListener) {
+        this.listener = listener
+    }
+
+    override fun deactivate() {
+        listener = null
+    }
+
+    fun onLocationChanged(location: Location) {
+        listener?.onLocationChanged(location)
+    }
+}
+
+private fun newLocation(): Location {
+    val location = Location("MyLocationProvider")
+    location.apply {
+        latitude = singapore.latitude + Random.nextFloat()
+        longitude = singapore.longitude + Random.nextFloat()
+    }
+    return location
+}

--- a/app/src/main/java/com/google/maps/android/compose/MainActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MainActivity.kt
@@ -67,6 +67,13 @@ class MainActivity : ComponentActivity() {
                         }) {
                         Text(getString(R.string.map_in_column_activity))
                     }
+                    Spacer(modifier = Modifier.padding(5.dp))
+                    Button(
+                        onClick = {
+                            context.startActivity(Intent(context, LocationTrackingActivity::class.java))
+                        }) {
+                        Text(getString(R.string.location_tracking_activity))
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
   <string name="main_activity_title">"Maps Compose Demos \uD83D\uDDFA"</string>
   <string name="basic_map_activity">Basic Map Activity</string>
   <string name="map_in_column_activity">Map In Column Activity</string>
+  <string name="location_tracking_activity">Location Tracking Activity</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,5 +20,5 @@
   <string name="basic_map_activity">Basic Map Activity</string>
   <string name="map_in_column_activity">Map In Column Activity</string>
   <string name="map_clustering_activity">Map Clustering</string>
-  <string name="location_tracking_activity">Location Tracking Activity</string>
+  <string name="location_tracking_activity">Location Tracking</string>
 </resources>


### PR DESCRIPTION
This PR adds a new activity to the demo app to show how to use `LocationSource` and enable the "My location" layer. This allows you to move the blue "my location" dot around on the screen based on your own `Location` objects.

This implementation generates fake locations randomly every 2 seconds and updates the blue dot and animates the map camera accordingly:

![location-tracking](https://user-images.githubusercontent.com/928045/173444486-a202fd56-3ec6-4b08-b84f-61176229a745.gif)

We can also use this activity to demo the feature for the source of camera movement (https://github.com/googlemaps/android-maps-compose/issues/49) when that is implemented.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)