### PR TITLE
chore: Have app depend on local library vs. the published Maven Central artifact

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,9 +37,7 @@ android {
     }
 }
 
-// [START maps_android_compose_dependency]
 dependencies {
-    // [START_EXCLUDE silent]
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
@@ -57,17 +55,12 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 
-    // For debugging purposes, uncomment the implementation project declaration
-    // so that the sample app can use the local state of the `maps-compose`
-    // module.
-    // However, this should remain uncommented on the `main` branch so that
-    // the maven declaration of Maps Compose can be used as a snippet.
-    implementation project(':maps-compose')
-    // [END_EXCLUDE]
+    // Uncomment the implementation 'com.google...` declaration and comment out the project
+    // declaration if you want to test the sample app with a Maven Central release of the library.
     //implementation  "com.google.maps.android:maps-compose:2.2.1"
+    implementation project(':maps-compose')
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
 }
-// [END maps_android_compose_dependency]
 
 secrets {
     // To add your Maps API key to this project:


### PR DESCRIPTION
The project is currently deadlocked in a failing CI state as a result of the app depending on the latest Maven Central release of the library. We can't update the app to the newest release from Maven Central so CI passes because the release doesn't exist yet, and we can't publish a new release because the CI is failing:
https://github.com/googlemaps/android-maps-compose/runs/6889770989?check_suite_focus=true

This PR changes the app to depend on the local library so CI passes and the new release of the library can be published following the merge of this PR. Then we have the choice of switching the app back to depending on Maven Central release, or leaving depending on the local library.

@arriolac @wangela What are your thoughts on leaving the app depending on the local library? We have to keep switching back and forth, and the process includes merging failed CI builds by design, because we have it pinned to the last Maven Central release. Seems less risky to me to leave it depending on the local library so we have consistently passing CI.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
