### PR TITLE
chore: Normalize demo app Activity names

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,8 +17,8 @@
 <resources>
   <string name="app_name">android-maps-compose</string>
   <string name="main_activity_title">"Maps Compose Demos \uD83D\uDDFA"</string>
-  <string name="basic_map_activity">Basic Map Activity</string>
-  <string name="map_in_column_activity">Map In Column Activity</string>
+  <string name="basic_map_activity">Basic Map</string>
+  <string name="map_in_column_activity">Map In Column</string>
   <string name="map_clustering_activity">Map Clustering</string>
   <string name="location_tracking_activity">Location Tracking</string>
 </resources>


### PR DESCRIPTION
This PR normalizes the names of the demo app Activities by removing the word "Activity" from two of them to match the others that do not have "Activity".

Here's the new home screen look:

![image](https://user-images.githubusercontent.com/928045/175043562-c8d88a6e-7c04-43f3-ad9a-f03179c4aabb.png)

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
