### PR TITLE
feat: Add the reason for map camera movement

### DIFF
--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener.REASON_DEVELOPER_ANIMATION
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import org.junit.Assert.*
@@ -75,11 +76,13 @@ class GoogleMapViewTests {
     @Test
     fun testCameraReportsMoving() {
         initMap()
+        assertEquals(-1, cameraPositionState.cameraMoveStartedReason)
         zoom(shouldAnimate = true, zoomIn = true) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
             }
             assertTrue(cameraPositionState.isMoving)
+            assertEquals(REASON_DEVELOPER_ANIMATION, cameraPositionState.cameraMoveStartedReason)
         }
     }
 

--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener.REASON_DEVELOPER_ANIMATION
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import org.junit.Assert.*
@@ -76,13 +75,13 @@ class GoogleMapViewTests {
     @Test
     fun testCameraReportsMoving() {
         initMap()
-        assertEquals(-1, cameraPositionState.cameraMoveStartedReason)
+        assertEquals(CameraMoveStartedReason.NO_MOVEMENT_YET, cameraPositionState.cameraMoveStartedReason)
         zoom(shouldAnimate = true, zoomIn = true) {
             composeTestRule.waitUntil(1000) {
                 cameraPositionState.isMoving
             }
             assertTrue(cameraPositionState.isMoving)
-            assertEquals(REASON_DEVELOPER_ANIMATION, cameraPositionState.cameraMoveStartedReason)
+            assertEquals(CameraMoveStartedReason.DEVELOPER_ANIMATION, cameraPositionState.cameraMoveStartedReason)
         }
     }
 

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -67,7 +67,7 @@ class LocationTrackingActivity : AppCompatActivity() {
         setContent {
             var isMapLoaded by remember { mutableStateOf(false) }
 
-            // To control the map camera
+            // To control and observe the map camera
             val cameraPositionState = rememberCameraPositionState {
                 position = defaultCameraPosition
             }
@@ -86,6 +86,21 @@ class LocationTrackingActivity : AppCompatActivity() {
                 Log.d(TAG, "Updating camera position...")
                 val cameraPosition = CameraPosition.fromLatLngZoom(LatLng(locationState.value.latitude, locationState.value.longitude), zoom)
                 cameraPositionState.animate(CameraUpdateFactory.newCameraPosition(cameraPosition), 1_000)
+            }
+
+            // Detect when the map starts moving and print the reason
+            LaunchedEffect(cameraPositionState.isMoving) {
+                if (cameraPositionState.isMoving) {
+                    val reason = when(cameraPositionState.cameraMoveStartedReason) {
+                        // See https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants
+                        -1 -> "DEFAULT_NO_MOVEMENT_YET"
+                        1 -> "REASON_GESTURE"
+                        2 -> "REASON_API_ANIMATION"
+                        3 -> "REASON_DEVELOPER_ANIMATION"
+                        else -> "UNKNOWN"
+                    }
+                    Log.d(TAG, "Map camera started moving due to $reason")
+                }
             }
 
             Box(Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/LocationTrackingActivity.kt
@@ -91,15 +91,7 @@ class LocationTrackingActivity : AppCompatActivity() {
             // Detect when the map starts moving and print the reason
             LaunchedEffect(cameraPositionState.isMoving) {
                 if (cameraPositionState.isMoving) {
-                    val reason = when(cameraPositionState.cameraMoveStartedReason) {
-                        // See https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants
-                        -1 -> "DEFAULT_NO_MOVEMENT_YET"
-                        1 -> "REASON_GESTURE"
-                        2 -> "REASON_API_ANIMATION"
-                        3 -> "REASON_DEVELOPER_ANIMATION"
-                        else -> "UNKNOWN"
-                    }
-                    Log.d(TAG, "Map camera started moving due to $reason")
+                    Log.d(TAG, "Map camera started moving due to ${cameraPositionState.cameraMoveStartedReason.name}")
                 }
             }
 

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraMoveStartedReason.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraMoveStartedReason.kt
@@ -1,0 +1,52 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.maps.android.compose
+
+import androidx.compose.runtime.Immutable
+import com.google.maps.android.compose.CameraMoveStartedReason.Companion.fromInt
+import com.google.maps.android.compose.CameraMoveStartedReason.NO_MOVEMENT_YET
+import com.google.maps.android.compose.CameraMoveStartedReason.UNKNOWN
+
+/**
+ * Enumerates the different reasons why the map camera started to move.
+ *
+ * Based on enum values from https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants.
+ *
+ * [NO_MOVEMENT_YET] is used as the initial state before any map movement has been observed.
+ *
+ * [UNKNOWN] is used to represent when an unsupported integer value is provided to [fromInt] - this
+ * may be a new constant value from the Maps SDK that isn't supported by maps-compose yet, in which
+ * case this library should be updated to include a new enum value for that constant.
+ */
+@Immutable
+public enum class CameraMoveStartedReason(public val value: Int) {
+    UNKNOWN(-2),
+    NO_MOVEMENT_YET(-1),
+    GESTURE(com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE),
+    API_ANIMATION(com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener.REASON_API_ANIMATION),
+    DEVELOPER_ANIMATION(com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener.REASON_DEVELOPER_ANIMATION);
+
+    public companion object {
+        /**
+         * Converts from the Maps SDK [com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener]
+         * constants to [CameraMoveStartedReason], or returns [UNKNOWN] if there is no such
+         * [CameraMoveStartedReason] for the given [value].
+         *
+         * See https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants.
+         */
+        public fun fromInt(value: Int): CameraMoveStartedReason {
+            return values().firstOrNull { it.value == value } ?: return UNKNOWN
+        }
+    }
+}

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -27,12 +27,7 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.Projection
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
-import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.*
 import java.lang.Integer.MAX_VALUE
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -65,6 +60,13 @@ public class CameraPositionState(
      * panning, zooming, or rotation.
      */
     public var isMoving: Boolean by mutableStateOf(false)
+        internal set
+
+    /**
+     * The reason for the start of the most recent camera moment, or -1 if the camera hasn't moved
+     * yet. See constant definitions at https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants.
+     */
+    public var cameraMoveStartedReason: Int by mutableStateOf(-1)
         internal set
 
     /**

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -30,6 +30,7 @@ import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.lang.Integer.MAX_VALUE

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -27,7 +27,11 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.Projection
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.lang.Integer.MAX_VALUE
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -63,10 +63,13 @@ public class CameraPositionState(
         internal set
 
     /**
-     * The reason for the start of the most recent camera moment, or -1 if the camera hasn't moved
-     * yet. See constant definitions at https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants.
+     * The reason for the start of the most recent camera moment, or
+     * [CameraMoveStartedReason.NO_MOVEMENT_YET] if the camera hasn't moved yet or
+     * [CameraMoveStartedReason.UNKNOWN] if an unknown constant is received from the Maps SDK.
      */
-    public var cameraMoveStartedReason: Int by mutableStateOf(-1)
+    public var cameraMoveStartedReason: CameraMoveStartedReason by mutableStateOf(
+        CameraMoveStartedReason.NO_MOVEMENT_YET
+    )
         internal set
 
     /**

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
@@ -69,6 +69,7 @@ internal class MapPropertiesNode(
             cameraPositionState.isMoving = false
         }
         map.setOnCameraMoveStartedListener {
+            cameraPositionState.cameraMoveStartedReason = it
             cameraPositionState.isMoving = true
         }
         map.setOnCameraMoveListener {

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapUpdater.kt
@@ -69,7 +69,7 @@ internal class MapPropertiesNode(
             cameraPositionState.isMoving = false
         }
         map.setOnCameraMoveStartedListener {
-            cameraPositionState.cameraMoveStartedReason = it
+            cameraPositionState.cameraMoveStartedReason = CameraMoveStartedReason.fromInt(it)
             cameraPositionState.isMoving = true
         }
         map.setOnCameraMoveListener {


### PR DESCRIPTION
As discussed in https://github.com/googlemaps/android-maps-compose/issues/49, this PR exposes the `reason` value passed back in `GoogleMap.OnCameraMoveStartedListener(int reason)` callback so that developers can tell the reason that the camera started moving (e.g., user gesture, developer animation, API animation):
https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#onCameraMoveStarted(int)

For constant values see:
https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener#constants

The PR also adds demo code to `LocationTrackingActivity` to print the reason that the camera moves, as well as assertions to test behavior in an existing unit test.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes https://github.com/googlemaps/android-maps-compose/issues/49 🦕
