### PR TITLE
fix: DisappearingScaleBar do not disappear after specified visibilityDurationMillis

### DIFF
--- a/maps-compose-widgets/src/main/java/com/google/maps/android/compose/widgets/ScaleBar.kt
+++ b/maps-compose-widgets/src/main/java/com/google/maps/android/compose/widgets/ScaleBar.kt
@@ -213,14 +213,11 @@ public fun DisappearingScaleBar(
     }
 
     LaunchedEffect(key1 = cameraPositionState.position.zoom) {
-        if (visible.isIdle && !visible.currentState) {
-            // Show ScaleBar
-            visible.targetState = true
-        } else if (visible.isIdle && visible.currentState) {
-            // Hide ScaleBar after timeout period
-            delay(visibilityDurationMillis.toLong())
-            visible.targetState = false
-        }
+        // Show ScaleBar
+        visible.targetState = true
+        delay(visibilityDurationMillis.toLong())
+        // Hide ScaleBar after timeout period
+        visible.targetState = false
     }
 
     AnimatedVisibility(


### PR DESCRIPTION
Addresses a fix for #166 where DisappearingScaleBar does not disappear after specified visibilityDurationMillis. I think it's good to remove the condition so that the visibility and delay will restart every time the zoom changes. This will make sure that after given visibilityDurationMillis the ScaleBar will disappear. Also, any zoom change will restart the LaunchedEffect again so that the old time-out will not be an issue.

I would love to hear the feedback if this is the correct way to address the issue or not. Any comments will be valuable.

Fixes #166 