### PR TITLE
fix: DisappearingScaleBar modifier (e.g., for alignment)

### DIFF
--- a/app/src/main/java/com/google/maps/android/compose/ScaleBarActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/ScaleBarActivity.kt
@@ -68,7 +68,7 @@ class ScaleBarActivity : ComponentActivity() {
                 )
                 DisappearingScaleBar(
                     modifier = Modifier
-                        .padding(top = 5.dp, end = 15.dp)
+                        .padding(top = 5.dp, start = 10.dp)
                         .align(Alignment.TopStart),
                     cameraPositionState = cameraPositionState
                 )

--- a/maps-compose-widgets/src/main/java/com/google/maps/android/compose/widgets/ScaleBar.kt
+++ b/maps-compose-widgets/src/main/java/com/google/maps/android/compose/widgets/ScaleBar.kt
@@ -225,11 +225,11 @@ public fun DisappearingScaleBar(
 
     AnimatedVisibility(
         visibleState = visible,
+        modifier = modifier,
         enter = enterTransition,
         exit = exitTransition
     ) {
         ScaleBar(
-            modifier = modifier,
             width = width,
             height = height,
             cameraPositionState = cameraPositionState,


### PR DESCRIPTION
This PR fixes the modifier (e.g., for alignment) for the DisappearingScaleBar by passing it into the `AnimatedVisibility` instead of `ScaleBar`.

Also tweaks/fixes the demo app padding.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes https://github.com/googlemaps/android-maps-compose/issues/165 🦕
