### PR TITLE
chore: Update Compose libraries and Compiler.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 32
 
     defaultConfig {
         applicationId "com.google.maps.android.compose"
         minSdk 21
-        targetSdk 31
+        targetSdk 32
         versionCode 1
         versionName "1.0"
 
@@ -23,7 +23,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_version"
+        kotlinCompilerExtensionVersion "$compose_compiler_version"
     }
 
     buildFeatures {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.6.21'
-    ext.compose_version = '1.2.0-beta02'
+    ext.kotlin_version = '1.7.0'
+    ext.compose_compiler_version = '1.2.0'
+    ext.compose_version = '1.2.0-rc03'
     ext.androidx_test_version = '1.4.0'
     repositories {
         google()

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 32
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 32
         versionCode 1
         versionName "1.0"
     }
@@ -19,7 +19,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_version"
+        kotlinCompilerExtensionVersion "$compose_compiler_version"
     }
 
     buildFeatures {

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 32
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 32
         versionCode 1
         versionName "1.0"
     }
@@ -19,7 +19,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_version"
+        kotlinCompilerExtensionVersion "$compose_compiler_version"
     }
 
     buildFeatures {

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Polygon.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Polygon.kt
@@ -76,8 +76,8 @@ public fun Polygon(
                 clickable(clickable)
                 fillColor(fillColor.toArgb())
                 geodesic(geodesic)
-                holes.forEach {
-                    addHole(it)
+                for (hole in holes) {
+                    addHole(hole)
                 }
                 strokeColor(strokeColor.toArgb())
                 strokeJointType(strokeJointType)


### PR DESCRIPTION
Compose now supports independent versioning: https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html

* Updates compose compiler to the stable version (1.2.0)
* Updates compose libraries to the latest 1.2.0 rc (1.2.0-rc03)
* Updates target/compile SDK to 32