### PR TITLE
chore: Use pull_request_target.

### DIFF
--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -22,6 +22,8 @@ on:
     branches-ignore: ['gh-pages']
   pull_request:
     branches-ignore: ['gh-pages']
+  pull_request_target:
+    branches-ignore: ['gh-pages']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ on:
     branches-ignore: ['gh-pages']
   pull_request:
     branches-ignore: ['gh-pages']
+  pull_request_target:
+    branches-ignore: ['gh-pages']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Use `pull_request_target` so that PRs from forked repos have access to secrets. This should fix failed runs due to the Maps API key not being injected: https://github.com/googlemaps/android-maps-compose/runs/7283340731

Relates to #174  🦕
