### PR TITLE
feat: Use version catalog for dependency management

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_compiler_version"
+        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
     }
 
     buildFeatures {
@@ -38,24 +38,24 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.activity:activity-compose:1.4.0'
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'com.google.maps.android:maps-ktx:3.3.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.maps.android:android-maps-utils:2.3.0'
-    implementation 'androidx.compose.ui:ui-tooling-preview:1.1.1'
-    debugImplementation 'androidx.compose.ui:ui-tooling:1.1.1'
+    implementation libs.androidx.compose.activity
+    implementation libs.androidx.compose.foundation
+    implementation libs.androidx.compose.material
+    implementation libs.kotlin
+    implementation libs.material
+    implementation libs.maps.ktx.std
+    implementation libs.maps.utils
+    implementation libs.androidx.compose.ui.preview.tooling
+    debugImplementation libs.androidx.compose.ui.tooling
 
-    androidTestImplementation "androidx.test:core:$androidx_test_version"
-    androidTestImplementation "androidx.test:rules:$androidx_test_version"
-    androidTestImplementation "androidx.test:runner:$androidx_test_version"
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.3'
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
+    androidTestImplementation libs.androidx.test.core
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.espresso
+    androidTestImplementation libs.androidx.test.junit.ktx
+    androidTestImplementation libs.test.junit
+    androidTestImplementation libs.androidx.test.compose.ui
+    androidTestImplementation libs.coroutines
 
     // Uncomment the implementation 'com.google...` declaration and comment out the project
     // declaration if you want to test the sample app with a Maven Central release of the library.
@@ -63,7 +63,7 @@ dependencies {
     implementation project(':maps-compose')
     //implementation  "com.google.maps.android:maps-compose-widgets:1.0.0"
     implementation project(':maps-compose-widgets')
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
+    implementation libs.maps.playservice
 }
 
 secrets {

--- a/build.gradle
+++ b/build.gradle
@@ -9,16 +9,16 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.5.0'
-        classpath 'com.hiya:jacoco-android:0.2'
+        classpath libs.android.gradle.plugin
+        classpath libs.maps.secrets.plugin
+        classpath libs.kotlin.gradle.plugin
+        classpath libs.dokka.plugin
+        classpath libs.jacoco.android.plugin
     }
 }
 
 plugins {
-    id 'org.jetbrains.dokka' version '1.5.0'
+    alias libs.plugins.dokka apply false
 }
 
 ext.projectArtifactId = { project ->
@@ -49,7 +49,7 @@ subprojects { project ->
 
     // Code coverage
     jacoco {
-        toolVersion = "0.8.7"
+        toolVersion = libs.versions.jacoco.tool.plugin.get()
     }
 
     tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.0'
-    ext.compose_compiler_version = '1.2.0'
-    ext.compose_version = '1.2.0-rc03'
-    ext.androidx_test_version = '1.4.0'
+    ext.kotlin_version = libs.versions.kotlin.get()
+    ext.compose_compiler_version = libs.versions.composecompiler.get()
+    ext.compose_version = libs.versions.compose.get()
+    ext.androidx_test_version = libs.versions.androidxtest.get()
     repositories {
         google()
         mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,34 @@
+[versions]
+activitycompose = "1.4.0"
+androidxtest = "1.4.0"
+compose = "1.2.0-rc03"
+composecompiler = "1.2.0"
+coroutines = "1.6.0"
+espresso = "3.4.0"
+junitktx = "1.1.3"
+junit = "4.13.2"
+kotlin = "1.7.0"
+material = "1.5.0"
+maps = "3.3.0"
+
+[libraries]
+androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activitycompose" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+androidx-core = { module = "androidx.core:core-ktx", version.require = "1.7.0" }
+androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxtest" }
+androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitktx" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxtest" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxtest" }
+coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
+maps-ktx-std = { module = "com.google.maps.android:maps-ktx", version.ref = "maps" }
+maps-ktx-utils = { module = "com.google.maps.android:maps-utils-ktx", version.ref = "maps" }
+maps-utils = { module = "com.google.maps.android:android-maps-utils", version.require = "2.3.0" }
+maps-playservice = { module = "com.google.android.gms:play-services-maps", version.require = "18.0.2" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+test-junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,23 @@
 [versions]
 activitycompose = "1.4.0"
+agp = "7.2.0"
 androidxtest = "1.4.0"
 compose = "1.2.0-rc03"
 composecompiler = "1.2.0"
 coroutines = "1.6.0"
+dokka = "1.5.0"
 espresso = "3.4.0"
+jacoco-plugin = "0.2"
+jacoco-tool-plugin = "0.8.7"
 junitktx = "1.1.3"
 junit = "4.13.2"
 kotlin = "1.7.0"
 material = "1.5.0"
 maps = "3.3.0"
+mapsecrets = "2.0.1"
 
 [libraries]
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activitycompose" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
@@ -25,10 +31,17 @@ androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref 
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxtest" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxtest" }
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+jacoco-android-plugin = { module = "com.hiya:jacoco-android", version.ref = "jacoco-plugin" }
 kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 maps-ktx-std = { module = "com.google.maps.android:maps-ktx", version.ref = "maps" }
 maps-ktx-utils = { module = "com.google.maps.android:maps-utils-ktx", version.ref = "maps" }
 maps-utils = { module = "com.google.maps.android:android-maps-utils", version.require = "2.3.0" }
 maps-playservice = { module = "com.google.android.gms:play-services-maps", version.require = "18.0.2" }
+maps-secrets-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "mapsecrets" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 test-junit = { module = "junit:junit", version.ref = "junit" }
+
+[plugins]
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -19,7 +19,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_compiler_version"
+        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
     }
 
     buildFeatures {
@@ -35,17 +35,18 @@ android {
 }
 
 dependencies {
-    implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation project(':maps-compose')
-    implementation 'androidx.compose.material:material:1.1.1'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
-    implementation 'com.google.maps.android:maps-ktx:3.4.0'
-    implementation 'com.google.maps.android:maps-utils-ktx:3.3.0'
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation libs.androidx.compose.foundation
+    implementation libs.androidx.compose.material
+    implementation libs.androidx.core
+    implementation libs.kotlin
+    implementation libs.maps.playservice
+    implementation libs.maps.ktx.std
+    implementation libs.maps.ktx.utils
+
+    testImplementation libs.test.junit
+
+    androidTestImplementation libs.androidx.test.espresso
+    androidTestImplementation libs.androidx.test.junit.ktx
 }

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -19,7 +19,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "$compose_compiler_version"
+        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
     }
 
     buildFeatures {
@@ -35,14 +35,14 @@ android {
 }
 
 dependencies {
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
-    implementation 'com.google.maps.android:maps-ktx:3.4.0'
+    implementation libs.androidx.core
+    implementation libs.androidx.compose.foundation
+    implementation libs.kotlin
+    implementation libs.maps.playservice
+    implementation libs.maps.ktx.std
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation libs.test.junit
+
+    androidTestImplementation libs.androidx.test.espresso
+    androidTestImplementation libs.androidx.test.junit.ktx
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+enableFeaturePreview("VERSION_CATALOGS")
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
First of all, thanks for an awesome project! 🤩 I really like it!

In this PR I have tried to implement version catalog for dependency management.  This is important to ensure consistency in library versions across modules.

~~There are some things to consider. The AGP version is not yet updated (7.0.4) and therefore [version catalog]~~
~~(https://docs.gradle.org/current/userguide/platforms.html) is still experimental.  However, since there was a PR on~~ 
~~this ([181](https://github.com/googlemaps/android-maps-compose/pull/181)) I thought this was okay. Then I can~~
 ~~rebase and remove the `enableFeaturePreview` flag when that is merged. Furthermore, I have not~~
~~implemented `plugins` in `library.versions.toml` as that is a feature that was added in version 7.2 of gradle.~~

Update: Rebased on #181, used plugins from version catalog and updated the root gradle file 😄 

---
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #172 🦕
Fixes #160 🦕


