### PR TITLE
fix: Prevent a memory leak on AndroidView which may not call ON_DESTROY

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -175,6 +175,8 @@ private fun MapLifecycle(mapView: MapView) {
         onDispose {
             lifecycle.removeObserver(mapLifecycleObserver)
             context.unregisterComponentCallbacks(callbacks)
+            mapView.onDestroy()
+            mapView.removeAllViews()
         }
     }
 }
@@ -195,7 +197,9 @@ private fun MapView.lifecycleObserver(previousState: MutableState<Lifecycle.Even
             Lifecycle.Event.ON_RESUME -> this.onResume()
             Lifecycle.Event.ON_PAUSE -> this.onPause()
             Lifecycle.Event.ON_STOP -> this.onStop()
-            Lifecycle.Event.ON_DESTROY -> this.onDestroy()
+            Lifecycle.Event.ON_DESTROY -> {
+                //handled in onDispose
+            }
             else -> throw IllegalStateException()
         }
         previousState.value = event


### PR DESCRIPTION
This PR fixes a memory leak that can happen in AndroidView when navigating to another screen.
The Lifecycle ON_DESTROY event is never called because in onDispose we remove the mapLifecycleObserver and this method is called before the Lifecycle ON_DESTROY event.

We have to handle any Lifecycle ON_DESTROY in the onDispose method.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #138 🦕
