### PR TITLE
Update blunderbuss.yml

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 assign_issues:
-  - barbeau
+  - 
 assign_prs:
-  - barbeau
+  - wangela


### PR DESCRIPTION
- Remove barbeau from auto-assignment list.
- Assign PRs to wangela
