### PR TITLE
chore: Disable flaky test.

### DIFF
--- a/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
@@ -112,17 +112,18 @@ class MapInColumnTests {
         }
     }
 
-    @Test
-    fun testScrollColumn_MapCameraRemainsSame() {
-        initMap()
-        // Check that the column scrolls to the last item
-        composeTestRule.onRoot().performTouchInput { swipeUp() }
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("Item 1").assertIsNotDisplayed()
-
-        // Check that the map didn't change
-        startingPosition.assertEquals(cameraPositionState.position.target)
-    }
+    // FIXME: https://github.com/googlemaps/android-maps-compose/issues/174
+//    @Test
+//    fun testScrollColumn_MapCameraRemainsSame() {
+//        initMap()
+//        // Check that the column scrolls to the last item
+//        composeTestRule.onRoot().performTouchInput { swipeUp() }
+//        composeTestRule.waitForIdle()
+//        composeTestRule.onNodeWithTag("Item 1").assertIsNotDisplayed()
+//
+//        // Check that the map didn't change
+//        startingPosition.assertEquals(cameraPositionState.position.target)
+//    }
 
 //    @Test
 //    fun testPanMapUp_MapCameraChangesColumnDoesNotScroll() {


### PR DESCRIPTION
Disables flaky test on CI.

I decided to disable it since commits have been landing to `main` despite the test failing.
It's a known env-specific issue and I think disabling this is the right move so that merges
aren't accidentally made when a different failure happens. This should be uncommented again 
and addressed as part of #174.
