### PR TITLE
chore: Disable flaky test.

### DIFF
--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -22,8 +22,6 @@ on:
     branches-ignore: ['gh-pages']
   pull_request:
     branches-ignore: ['gh-pages']
-  pull_request_target:
-    branches-ignore: ['gh-pages']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ on:
     branches-ignore: ['gh-pages']
   pull_request:
     branches-ignore: ['gh-pages']
-  pull_request_target:
-    branches-ignore: ['gh-pages']
   workflow_dispatch:
 
 jobs:

--- a/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
@@ -112,17 +112,18 @@ class MapInColumnTests {
         }
     }
 
-    @Test
-    fun testScrollColumn_MapCameraRemainsSame() {
-        initMap()
-        // Check that the column scrolls to the last item
-        composeTestRule.onRoot().performTouchInput { swipeUp() }
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("Item 1").assertIsNotDisplayed()
-
-        // Check that the map didn't change
-        startingPosition.assertEquals(cameraPositionState.position.target)
-    }
+    // FIXME: https://github.com/googlemaps/android-maps-compose/issues/174
+//    @Test
+//    fun testScrollColumn_MapCameraRemainsSame() {
+//        initMap()
+//        // Check that the column scrolls to the last item
+//        composeTestRule.onRoot().performTouchInput { swipeUp() }
+//        composeTestRule.waitForIdle()
+//        composeTestRule.onNodeWithTag("Item 1").assertIsNotDisplayed()
+//
+//        // Check that the map didn't change
+//        startingPosition.assertEquals(cameraPositionState.position.target)
+//    }
 
 //    @Test
 //    fun testPanMapUp_MapCameraChangesColumnDoesNotScroll() {


### PR DESCRIPTION
Disables flaky test on CI.

I decided to disable it since commits have been landing to `main` despite the test failing. It's a known env-specific issue and  I think disabling this is the right move so that merges aren't accidentally made when a different failure happens. This should be uncommented again and addressed as part of https://github.com/googlemaps/android-maps-compose/issues/174.