### PR TITLE
chore: Use BOM for Compose deps and bump compiler to 1.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
     ext.kotlin_version = libs.versions.kotlin.get()
     ext.compose_compiler_version = libs.versions.composecompiler.get()
-    ext.compose_version = libs.versions.compose.get()
     ext.androidx_test_version = libs.versions.androidxtest.get()
     repositories {
         google()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,8 @@
 [versions]
-activitycompose = "1.4.0"
 agp = "7.2.0"
 androidxtest = "1.4.0"
-compose = "1.2.1"
-composecompiler = "1.3.0"
+compose-bom = "2022.10.00"
+composecompiler = "1.3.2"
 coroutines = "1.6.0"
 dokka = "1.5.0"
 espresso = "3.4.0"
@@ -11,20 +10,21 @@ jacoco-plugin = "0.2"
 jacoco-tool-plugin = "0.8.7"
 junitktx = "1.1.3"
 junit = "4.13.2"
-kotlin = "1.7.10"
+kotlin = "1.7.20"
 material = "1.5.0"
 maps = "3.3.0"
 mapsecrets = "2.0.1"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activitycompose" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+androidx-compose-activity = { module = "androidx.activity:activity-compose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-core = { module = "androidx.core:core-ktx", version.require = "1.7.0" }
-androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxtest" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitktx" }


### PR DESCRIPTION
Fixes #219 🦕
