### PR TITLE
chore: Use BOM for Compose deps and bump compiler to 1.3.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation libs.androidx.compose.ui.preview.tooling
     debugImplementation libs.androidx.compose.ui.tooling
 
-    androidTestImplementation libs.androidx.compose.bom
+    androidTestImplementation platform(libs.androidx.compose.bom)
     androidTestImplementation libs.androidx.test.core
     androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.androidx.test.runner

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace "com.google.maps.android.compose"
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ android {
 }
 
 dependencies {
+    implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.compose.activity
     implementation libs.androidx.compose.foundation
     implementation libs.androidx.compose.material
@@ -48,6 +49,7 @@ dependencies {
     implementation libs.androidx.compose.ui.preview.tooling
     debugImplementation libs.androidx.compose.ui.tooling
 
+    androidTestImplementation libs.androidx.compose.bom
     androidTestImplementation libs.androidx.test.core
     androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.androidx.test.runner

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
     ext.kotlin_version = libs.versions.kotlin.get()
     ext.compose_compiler_version = libs.versions.composecompiler.get()
-    ext.compose_version = libs.versions.compose.get()
     ext.androidx_test_version = libs.versions.androidxtest.get()
     repositories {
         google()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,8 @@
 [versions]
-activitycompose = "1.4.0"
 agp = "7.3.1"
 androidxtest = "1.4.0"
-compose = "1.2.1"
-composecompiler = "1.3.0"
+compose-bom = "2022.10.00"
+composecompiler = "1.3.2"
 coroutines = "1.6.0"
 dokka = "1.5.0"
 espresso = "3.4.0"
@@ -11,20 +10,21 @@ jacoco-plugin = "0.2"
 jacoco-tool-plugin = "0.8.7"
 junitktx = "1.1.3"
 junit = "4.13.2"
-kotlin = "1.7.10"
+kotlin = "1.7.20"
 material = "1.5.0"
 maps = "3.3.0"
 mapsecrets = "2.0.1"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activitycompose" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+androidx-compose-activity = { module = "androidx.activity:activity-compose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-core = { module = "androidx.core:core-ktx", version.require = "1.7.0" }
-androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxtest" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitktx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "7.3.1"
 androidxtest = "1.4.0"
-compose-bom = "2022.10.00"
+compose-bom = "2022.11.00"
 composecompiler = "1.3.2"
 coroutines = "1.6.0"
 dokka = "1.5.0"
@@ -18,7 +18,7 @@ mapsecrets = "2.0.1"
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 androidx-compose-activity = { module = "androidx.activity:activity-compose" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
 androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+activitycompose = "1.6.1"
 agp = "7.3.1"
 androidxtest = "1.4.0"
 compose-bom = "2022.11.00"
@@ -17,7 +18,7 @@ mapsecrets = "2.0.1"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-androidx-compose-activity = { module = "androidx.activity:activity-compose" }
+androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activitycompose" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material = { module = "androidx.compose.material:material" }

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace "com.google.maps.android.compose.widgets"
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
     }

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -38,6 +38,7 @@ android {
 dependencies {
     implementation project(':maps-compose')
 
+    implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.compose.foundation
     implementation libs.androidx.compose.material
     implementation libs.androidx.core
@@ -47,7 +48,7 @@ dependencies {
     implementation libs.maps.ktx.utils
 
     testImplementation libs.test.junit
-
+    androidTestImplementation libs.androidx.compose.bom
     androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.androidx.test.junit.ktx
 }

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation libs.maps.ktx.utils
 
     testImplementation libs.test.junit
-    androidTestImplementation libs.androidx.compose.bom
+    androidTestImplementation platform(libs.androidx.compose.bom)
     androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.androidx.test.junit.ktx
 }

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     testImplementation libs.test.junit
 
-    androidTestImplementation libs.androidx.compose.bom
+    androidTestImplementation platform(libs.androidx.compose.bom)
     androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.androidx.test.junit.ktx
 }

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -36,6 +36,7 @@ android {
 }
 
 dependencies {
+    implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.core
     implementation libs.androidx.compose.foundation
     implementation libs.kotlin
@@ -44,6 +45,7 @@ dependencies {
 
     testImplementation libs.test.junit
 
+    androidTestImplementation libs.androidx.compose.bom
     androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.androidx.test.junit.ktx
 }

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace "com.google.maps.android.compose"
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Fixes #219  🦕
