### PR TITLE
fix: Separate MapView disposal from LifecycleOwner changes

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -177,6 +177,10 @@ private fun MapLifecycle(mapView: MapView) {
         onDispose {
             lifecycle.removeObserver(mapLifecycleObserver)
             context.unregisterComponentCallbacks(callbacks)
+        }
+    }
+    DisposableEffect(mapView) {
+        onDispose {
             mapView.onDestroy()
             mapView.removeAllViews()
         }


### PR DESCRIPTION
#206 introduced a crash when disposing the MapView, as reported in #207. Since the `DisposableEffect` has multiple keys, changes to any of them will result in the MapView becoming destroyed, which is not necessarily what we want. [This repro project](https://github.com/thekingrenz23/GoogleMapsBottomNav) (extremely helpful, thank you @thekingrenz23!) revealed a case where the lifecycle owner (one of the DisposableEffect keys) can change without changing the MapView or context. This puts the MapView into a bad state, where it's "destroyed" but still shown and fully interactible.
This moves the MapView disposal into its own DisposableEffect with _only_ the MapView as a key, avoiding the unwanted disposal.

Fixes #207 🦕
