### PR TITLE
perf: Make MarkerState stable

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -81,13 +82,15 @@ public class MarkerState(
         internal set
 
     // The marker associated with this MarkerState.
-    internal var marker: Marker? = null
+    private val markerState: MutableState<Marker?> = mutableStateOf(null)
+    internal var marker: Marker?
+        get() = markerState.value
         set(value) {
-            if (field == null && value == null) return
-            if (field != null && value != null) {
+            if (markerState.value == null && value == null) return
+            if (markerState.value != null && value != null) {
                 error("MarkerState may only be associated with one Marker at a time.")
             }
-            field = value
+            markerState.value = value
         }
 
     /**


### PR DESCRIPTION
`MarkerState`'s `internal var: Marker?` property was causing the class to be marked unstable.
While I think it can safely be marked `@Stable` as-is, I'd rather have the compiler infer that. I feel better backing it with an actual state value, that way if we later do an actual non-imperative state read it won't break stuff.
Verified stability via compiler report.

Fixes #232 🦕