### PR TITLE
perf: Make CameraPositionState stable

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -110,16 +110,16 @@ public class CameraPositionState(
 
     // Used to perform side effects thread-safely.
     // Guards all mutable properties that are not `by mutableStateOf`.
-    private val lock = Any()
+    private val lock = Unit
 
     // The map currently associated with this CameraPositionState.
     // Guarded by `lock`.
-    private var map: GoogleMap? = null
+    private var map: GoogleMap? by mutableStateOf(null)
 
     // An action to run when the map becomes available or unavailable.
     // represents a mutually exclusive mutation to perform while holding `lock`.
     // Guarded by `lock`.
-    private var onMapChanged: OnMapChangedCallback? = null
+    private var onMapChanged: OnMapChangedCallback? by mutableStateOf(null)
 
     /**
      * Set [onMapChanged] to [callback], invoking the current callback's
@@ -133,7 +133,7 @@ public class CameraPositionState(
     // A token representing the current owner of any ongoing motion in progress.
     // Used to determine if map animation should stop when calls to animate end.
     // Guarded by `lock`.
-    private var movementOwner: Any? = null
+    private var movementOwner: Any? by mutableStateOf(null)
 
     /**
      * Used with [onMapChangedLocked] to execute one-time actions when a map becomes available


### PR DESCRIPTION
`CameraPositionState` has a few unstable properties. Rather than verify all usages of these are safe for stability, I'm opting to back them with mutable states, so the compiler can mark the class stable for us.
Verified stability via compiler report.