### PR TITLE
chore: Remove no-longer-needed Version Catalogs feature flag

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
We're on a version of Gradle that has version catalogs enabled by default, so this flag isn't needed anymore.