### PR TITLE
fix: Migrate publication to AGP's publishing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,6 @@ dependencies {
     // Make sure to also include the latest version of the Maps SDK for Android 
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
     
-    // Also include Compose version `1.2.0-alpha03` or higher - for example:
-    implementation 'androidx.compose.foundation:foundation:2.8.0-alpha03'
-    
     // Optionally, you can include the widgets library if you want to use ScaleBar, etc.
     implementation 'com.google.maps.android:maps-compose-widgets:2.8.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,24 +56,21 @@ subprojects { project ->
         jacoco.excludes = ['jdk.internal.*']
     }
 
-    task sourcesJar(type: Jar) {
-        from android.sourceSets.main.java.source
-        archiveClassifier.set("sources")
-    }
-
-    task javadocJar(type: Jar) {
-        dependsOn(tasks.named("dokkaHtml"))
-        dependsOn(tasks.named("dokkaJavadoc"))
-        archiveClassifier.set("javadoc")
-        from new File(buildDir, "dokka/javadoc")
+    android {
+        publishing {
+            singleVariant("release") {
+                withSourcesJar()
+                withJavadocJar()
+            }
+        }
     }
 
     publishing {
         publications {
             aar(MavenPublication) {
-                groupId project.group
-                artifactId project.ext.artifactId
-                version project.version
+                afterEvaluate {
+                    from components.release
+                }
 
                 pom {
                     name = project.name
@@ -103,22 +100,6 @@ subprojects { project ->
                             name = 'Google Inc.'
                         }
                     }
-                }
-
-                pom.withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-                    project.configurations.api.allDependencies.each { dependency ->
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', dependency.group)
-                        dependencyNode.appendNode('artifactId', dependency.name)
-                        dependencyNode.appendNode('version', dependency.version)
-                    }
-                }
-
-                afterEvaluate {
-                    artifact "$buildDir/outputs/aar/$project.name-release.aar"
-                    artifact javadocJar
-                    artifact sourcesJar
                 }
             }
         }


### PR DESCRIPTION
This removes most of the custom setup of the Maven publication in favor of [AGP's components](https://developer.android.com/studio/publish-library).

Some notable changes:
- Before, the generated POM did not contain any dependencies. The old code suggests it might, but since it only adds dependencies from the `api` configuration, of which `:maps-compose` has none, the actual `<dependencies/>` block in the POM was empty.
With this change, the POM has expected dependencies, e.g. `play-services-maps`.
- Gradle Module metadata is now present in the publication. To my knowledge, this shouldn't result in any noticeable changes for users, as we aren't shipping test fixtures.

Generated Javadoc jar still contains Dokka stuff.