### PR TITLE
chore: Fail tests when API key is missing

### DIFF
--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -40,10 +40,7 @@ class GoogleMapViewTests {
     private lateinit var cameraPositionState: CameraPositionState
 
     private fun initMap(content: @Composable () -> Unit = {}) {
-        check(
-            BuildConfig.MAPS_API_KEY != "YOUR_API_KEY" && BuildConfig.MAPS_API_KEY.isNotBlank()
-        )
-        { "Maps API key not specified" }
+        check(hasValidApiKey) { "Maps API key not specified" }
         val countDownLatch = CountDownLatch(1)
         composeTestRule.setContent {
             GoogleMapView(

--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -40,7 +40,10 @@ class GoogleMapViewTests {
     private lateinit var cameraPositionState: CameraPositionState
 
     private fun initMap(content: @Composable () -> Unit = {}) {
-        check(BuildConfig.MAPS_API_KEY != "YOUR_API_KEY") { "Maps API key not specified" }
+        check(
+            BuildConfig.MAPS_API_KEY != "YOUR_API_KEY" && BuildConfig.MAPS_API_KEY.isNotBlank()
+        )
+        { "Maps API key not specified" }
         val countDownLatch = CountDownLatch(1)
         composeTestRule.setContent {
             GoogleMapView(

--- a/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -40,6 +40,7 @@ class GoogleMapViewTests {
     private lateinit var cameraPositionState: CameraPositionState
 
     private fun initMap(content: @Composable () -> Unit = {}) {
+        check(BuildConfig.MAPS_API_KEY != "YOUR_API_KEY") { "Maps API key not specified" }
         val countDownLatch = CountDownLatch(1)
         composeTestRule.setContent {
             GoogleMapView(

--- a/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
@@ -40,6 +40,7 @@ class MapInColumnTests {
     private lateinit var cameraPositionState: CameraPositionState
 
     private fun initMap(content: @Composable () -> Unit = {}) {
+        check(hasValidApiKey) { "Maps API key not specified" }
         val countDownLatch = CountDownLatch(1)
         composeTestRule.setContent {
             var scrollingEnabled by remember { mutableStateOf(true) }

--- a/app/src/androidTest/java/com/google/maps/android/compose/TestUtils.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/TestUtils.kt
@@ -4,6 +4,9 @@ import com.google.android.gms.maps.model.LatLng
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 
+val hasValidApiKey: Boolean =
+    BuildConfig.MAPS_API_KEY.isNotBlank() && BuildConfig.MAPS_API_KEY != "YOUR_API_KEY"
+
 const val assertRoundingError: Double = 0.01
 
 fun LatLng.assertEquals(other: LatLng) {


### PR DESCRIPTION
Currently when no API key is provided, the instrumentation tests fail with a cryptic "Map loaded" exception. This adds a more explicit error when no API key is provided.