### PR TITLE
chore: Use new Maps API secret in instrumentation tests

### DIFF
--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -47,7 +47,7 @@ jobs:
         # isn't picking up the key when creating a local.properties file here
         sed -i -e "s,\${MAPS_API_KEY},$MAPS_API_KEY,g" ./app/src/main/AndroidManifest.xml
       env:
-        MAPS_API_KEY: ${{ secrets.GMP_API_KEY }}
+        MAPS_API_KEY: ${{ secrets.SYNCED_GOOGLE_MAPS_API_KEY_ANDROID }}
 
     - name: Build debug
       run: ./gradlew assembleDebug


### PR DESCRIPTION
Follow-up to https://github.com/googlemaps/.github/pull/57