### PR TITLE
perf: Make CameraPositionState and MarkerState stable

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -110,16 +110,16 @@ public class CameraPositionState(
 
     // Used to perform side effects thread-safely.
     // Guards all mutable properties that are not `by mutableStateOf`.
-    private val lock = Any()
+    private val lock = Unit
 
     // The map currently associated with this CameraPositionState.
     // Guarded by `lock`.
-    private var map: GoogleMap? = null
+    private var map: GoogleMap? by mutableStateOf(null)
 
     // An action to run when the map becomes available or unavailable.
     // represents a mutually exclusive mutation to perform while holding `lock`.
     // Guarded by `lock`.
-    private var onMapChanged: OnMapChangedCallback? = null
+    private var onMapChanged: OnMapChangedCallback? by mutableStateOf(null)
 
     /**
      * Set [onMapChanged] to [callback], invoking the current callback's
@@ -133,7 +133,7 @@ public class CameraPositionState(
     // A token representing the current owner of any ongoing motion in progress.
     // Used to determine if map animation should stop when calls to animate end.
     // Guarded by `lock`.
-    private var movementOwner: Any? = null
+    private var movementOwner: Any? by mutableStateOf(null)
 
     /**
      * Used with [onMapChangedLocked] to execute one-time actions when a map becomes available

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -81,13 +82,15 @@ public class MarkerState(
         internal set
 
     // The marker associated with this MarkerState.
-    internal var marker: Marker? = null
+    private val markerState: MutableState<Marker?> = mutableStateOf(null)
+    internal var marker: Marker?
+        get() = markerState.value
         set(value) {
-            if (field == null && value == null) return
-            if (field != null && value != null) {
+            if (markerState.value == null && value == null) return
+            if (markerState.value != null && value != null) {
                 error("MarkerState may only be associated with one Marker at a time.")
             }
-            field = value
+            markerState.value = value
         }
 
     /**


### PR DESCRIPTION
`CameraPositionState` has a few unstable properties. Rather than verify all usages of these are safe for stability, I'm opting to back them with mutable states, so the compiler can mark the class stable for us.
`MarkerState`'s `internal var: Marker?` property was causing the class to be marked unstable.
While I think it can safely be marked `@Stable` as-is, I'd rather have the compiler infer that. I feel better backing it with an actual state value, that way if we later do an actual non-imperative state read it won't break stuff.

Verified stability via compiler report.

Fixes #232 🦕