### PR TITLE
chore: Upgrade AndroidX Test to 1.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activitycompose = "1.6.1"
 agp = "7.3.1"
-androidxtest = "1.4.0"
+androidxtest = "1.5.0"
 compose-bom = "2022.11.00"
 composecompiler = "1.3.2"
 coroutines = "1.6.0"


### PR DESCRIPTION
This fixes instrumentation tests on API 33, as reported in [b/240993946](https://issuetracker.google.com/issues/240993946).