### PR TITLE
feat: Add public currentCameraPositionState property

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -16,8 +16,7 @@ package com.google.maps.android.compose
 
 import androidx.annotation.UiThread
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocal
-import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
@@ -313,10 +312,9 @@ public class CameraPositionState(
     }
 }
 
-/** @see LocalCameraPositionState */
-internal val LocalProvidableCameraPositionState: ProvidableCompositionLocal<CameraPositionState> =
-    staticCompositionLocalOf { CameraPositionState() }
-
 /** Provides the [CameraPositionState] used by the map. */
-public val LocalCameraPositionState: CompositionLocal<CameraPositionState> =
-    LocalProvidableCameraPositionState
+internal val LocalCameraPositionState = staticCompositionLocalOf { CameraPositionState() }
+
+public val currentCameraPositionState: CameraPositionState
+    @[GoogleMapComposable ReadOnlyComposable Composable]
+    get() = LocalCameraPositionState.current

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -315,6 +315,7 @@ public class CameraPositionState(
 /** Provides the [CameraPositionState] used by the map. */
 internal val LocalCameraPositionState = staticCompositionLocalOf { CameraPositionState() }
 
+/** The current [CameraPositionState] used by the map. */
 public val currentCameraPositionState: CameraPositionState
     @[GoogleMapComposable ReadOnlyComposable Composable]
     get() = LocalCameraPositionState.current

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -16,11 +16,14 @@ package com.google.maps.android.compose
 
 import androidx.annotation.UiThread
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -309,3 +312,11 @@ public class CameraPositionState(
         )
     }
 }
+
+/** @see LocalCameraPositionState */
+internal val LocalProvidableCameraPositionState: ProvidableCompositionLocal<CameraPositionState> =
+    staticCompositionLocalOf { CameraPositionState() }
+
+/** Provides the [CameraPositionState] used by the map. */
+public val LocalCameraPositionState: CompositionLocal<CameraPositionState> =
+    LocalProvidableCameraPositionState

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -134,7 +134,7 @@ public fun GoogleMap(
                     mapUiSettings = currentUiSettings,
                 )
                 CompositionLocalProvider(
-                    LocalProvidableCameraPositionState provides cameraPositionState,
+                    LocalCameraPositionState provides cameraPositionState,
                 ) {
                     currentContent?.invoke()
                 }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -132,7 +133,11 @@ public fun GoogleMap(
                     mapProperties = currentMapProperties,
                     mapUiSettings = currentUiSettings,
                 )
-                currentContent?.invoke()
+                CompositionLocalProvider(
+                    LocalProvidableCameraPositionState provides cameraPositionState,
+                ) {
+                    currentContent?.invoke()
+                }
             }
         }
     }


### PR DESCRIPTION
As mentioned in https://github.com/googlemaps/android-maps-compose/pull/258#discussion_r1088385067, this makes the map's `CameraPositionState` globally accessible via a ~`CompositionLocal`~ public Composable property. Since the camera position state is global across the map, this should be safe to expose publicly. This is useful for components that are dependent on the camera state, such as Clustering ~and `ScaleBar`~.
Actually, since `ScaleBar` is a UI composable and not a Map composable, that doesn't work.

