### PR TITLE
chore: Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+# (not needed, since no requested libraries are pre-AndroidX)
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 


### PR DESCRIPTION
This disables Jetifier in the build. Jetifier is a compatibility tool that transforms pre-AndroidX libraries to make them use their AndroidX counterparts. Since this project has no pre-AndroidX libraries, it's not needed, so we can disable it as recommended by Android Studio's build analyzer.