### PR TITLE
chore: Remove Parcelize plugin

### DIFF
--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'kotlin-android'
-    id 'kotlin-parcelize'
 }
 
 android {

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'kotlin-android'
-    id 'kotlin-parcelize'
 }
 
 android {


### PR DESCRIPTION
As pointed out in #277, we don't need the Parcelize plugin, as we don't have any `@Parcelized` types.
Closes #277