### PR TITLE
fix: Fix Clustering not updating when new items are provided

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -78,9 +78,14 @@ public fun <T : ClusterItem> Clustering(
                 }
             }
     }
-    LaunchedEffect(items) {
-        clusterManager.clearItems()
-        clusterManager.addItems(items)
+    val itemsState = rememberUpdatedState(items)
+    LaunchedEffect(itemsState) {
+        snapshotFlow { itemsState.value.toList() }
+            .collect { items ->
+                clusterManager.clearItems()
+                clusterManager.addItems(items)
+                clusterManager.cluster()
+            }
     }
 }
 


### PR DESCRIPTION
This observes `items` via `snapshotFlow`, which fixes the case in #269 where a single `MutableStateList` of items is passed.

Fixes #269 🦕
