### PR TITLE
fix: Fix NoSuchElementException when rendering custom cluster content

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -139,9 +139,14 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
     override fun getDescriptorForCluster(cluster: Cluster<T>): BitmapDescriptor {
         return if (clusterContentState.value != null) {
             val viewInfo = keysToViews.entries
-                .first { (key, _) -> (key as? ViewKey.Cluster)?.cluster == cluster }
-                .value
-            renderViewToBitmapDescriptor(viewInfo.view)
+                .find { (key, _) -> (key as? ViewKey.Cluster)?.cluster == cluster }
+                ?.value
+            if (viewInfo != null) {
+                renderViewToBitmapDescriptor(viewInfo.view)
+            } else {
+                // Sometimes called for a marker that seems to be only transient
+                super.getDescriptorForCluster(cluster)
+            }
         } else {
             super.getDescriptorForCluster(cluster)
         }
@@ -152,9 +157,11 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
 
         if (clusterItemContentState.value != null) {
             val viewInfo = keysToViews.entries
-                .first { (key, _) -> (key as? ViewKey.Item)?.item == item }
-                .value
-            markerOptions.icon(renderViewToBitmapDescriptor(viewInfo.view))
+                .find { (key, _) -> (key as? ViewKey.Item)?.item == item }
+                ?.value
+            if (viewInfo != null) {
+                markerOptions.icon(renderViewToBitmapDescriptor(viewInfo.view))
+            } // Sometimes called for a marker that seems to be only transient, so do nothing
         }
     }
 

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -83,7 +83,7 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
         }
     }
 
-    private fun createAndAddView(key: ViewKey<T>) {
+    private fun createAndAddView(key: ViewKey<T>): ViewInfo {
         val view = InvalidatingComposeView(
             context,
             content = when (key) {
@@ -101,13 +101,15 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
             collectInvalidationsAndRerender(key, view)
         }
 
-        keysToViews[key] = ViewInfo(
+        val viewInfo = ViewInfo(
             view,
             onRemove = {
                 rerenderJob.cancel()
                 renderHandle.dispose()
             },
         )
+        keysToViews[key] = viewInfo
+        return viewInfo
     }
 
     /** Re-render the corresponding marker whenever [view] invalidates */
@@ -145,14 +147,10 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
     override fun getDescriptorForCluster(cluster: Cluster<T>): BitmapDescriptor {
         return if (clusterContentState.value != null) {
             val viewInfo = keysToViews.entries
-                .find { (key, _) -> (key as? ViewKey.Cluster)?.cluster == cluster }
+                .firstOrNull { (key, _) -> (key as? ViewKey.Cluster)?.cluster == cluster }
                 ?.value
-            if (viewInfo != null) {
-                renderViewToBitmapDescriptor(viewInfo.view)
-            } else {
-                // Sometimes called for a marker that seems to be only transient
-                super.getDescriptorForCluster(cluster)
-            }
+                ?: createAndAddView(cluster.computeViewKeys().first())
+            renderViewToBitmapDescriptor(viewInfo.view)
         } else {
             super.getDescriptorForCluster(cluster)
         }
@@ -163,11 +161,10 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
 
         if (clusterItemContentState.value != null) {
             val viewInfo = keysToViews.entries
-                .find { (key, _) -> (key as? ViewKey.Item)?.item == item }
+                .firstOrNull { (key, _) -> (key as? ViewKey.Item)?.item == item }
                 ?.value
-            if (viewInfo != null) {
-                markerOptions.icon(renderViewToBitmapDescriptor(viewInfo.view))
-            } // Sometimes called for a marker that seems to be only transient, so do nothing
+                ?: createAndAddView(ViewKey.Item(item))
+            markerOptions.icon(renderViewToBitmapDescriptor(viewInfo.view))
         }
     }
 


### PR DESCRIPTION
This fixes a crash when rendering custom cluster content. It seems to be timing-related. T cluster renderer creates markers that aren't actually meant to be rendered, so we don't have an active ComposeView for it. This works around it by simply no-op'ing when that happens.

Fixes #271 🦕
