### PR TITLE
fix: Expose maps-utils as API dependency from maps-compose-utils

### DIFF
--- a/maps-compose-utils/build.gradle
+++ b/maps-compose-utils/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     implementation libs.kotlin
     implementation libs.maps.playservice
     implementation libs.maps.ktx.std
-    implementation libs.maps.ktx.utils
+    api libs.maps.ktx.utils
 }


### PR DESCRIPTION
This changes `maps-utils` to be an API dependency, that way users don't have to add it manually.
