### PR TITLE
Fix: Clustering causes a crash in Navigation.

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -175,8 +175,8 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
         )
         view.layout(0, 0, view.measuredWidth, view.measuredHeight)
         val bitmap = Bitmap.createBitmap(
-            view.measuredWidth,
-            view.measuredHeight,
+            view.measuredWidth.takeIf { it > 0 } ?: 1,
+            view.measuredHeight.takeIf { it > 0 } ?: 1,
             Bitmap.Config.ARGB_8888
         )
         bitmap.applyCanvas {


### PR DESCRIPTION
The size of View becomes 0 by timing.
Cannot create a Bitmap with a size of 0, so put a 1.

Fixes #297 🦕
