### PR TITLE
fix: fixed crash when the Bitmap size is zero in the ClusterRenderer

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -179,8 +179,8 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
         )
         view.layout(0, 0, view.measuredWidth, view.measuredHeight)
         val bitmap = Bitmap.createBitmap(
-            view.measuredWidth,
-            view.measuredHeight,
+            view.measuredWidth.takeIf { it > 0 } ?: 1,
+            view.measuredHeight.takeIf { it > 0 } ?: 1,
             Bitmap.Config.ARGB_8888
         )
         bitmap.applyCanvas {


### PR DESCRIPTION
This PR prevents a crash when the Bitmap size is zero in the ClusterRenderer.

`measuredWidth` and `measuredHeight` typically return 0 when we call them from `onCreate`, which does not seem to be the case. This is also not deterministic and not always reproducible. For some reason, the view has not been drawn when we hit this point.

This PR will prevent the crash, although the causes need to be determined.

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #297
