### PR TITLE
chore: updated Google Maps SDK to 18.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 maps-ktx-std = { module = "com.google.maps.android:maps-ktx", version.ref = "maps" }
 maps-ktx-utils = { module = "com.google.maps.android:maps-utils-ktx", version.ref = "maps" }
 maps-utils = { module = "com.google.maps.android:android-maps-utils", version.require = "2.3.0" }
-maps-playservice = { module = "com.google.android.gms:play-services-maps", version.require = "18.0.2" }
+maps-playservice = { module = "com.google.android.gms:play-services-maps", version.require = "18.1.0" }
 maps-secrets-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "mapsecrets" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 test-junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
This PR updates Google Maps SDK to 18.1.0

18.1.0 introduces advanced polylines: https://developers.google.com/maps/documentation/android-sdk/release-notes

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #337
