### PR TITLE
chore: Improve Scalebar example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,19 +285,31 @@ The [ScaleBarActivity](app/src/main/java/com/google/maps/android/compose/ScaleBa
 Both versions of this widget leverage the `CameraPositionState` in `maps-compose` and therefore are very simple to configure with their defaults:
 
 ```kotlin
-ScaleBar(
-    modifier = Modifier
+Box(Modifier.fillMaxSize()) { 
+    
+    GoogleMap(
+        modifier = Modifier.fillMaxSize(),
+        cameraPositionState = cameraPositionState
+    ) {
+        // ... your map composables ...
+    }
+
+    ScaleBar(
+        modifier = Modifier
             .padding(top = 5.dp, end = 15.dp)
             .align(Alignment.TopEnd),
-    cameraPositionState = cameraPositionState
-)
+        cameraPositionState = cameraPositionState
+    )
 
-DisappearingScaleBar(
-    modifier = Modifier
+    // OR
+
+    DisappearingScaleBar(
+        modifier = Modifier
             .padding(top = 5.dp, end = 15.dp)
             .align(Alignment.TopStart),
-    cameraPositionState = cameraPositionState
-)
+        cameraPositionState = cameraPositionState
+    )
+}
 ```
 
 The colors of the text, line, and shadow are also all configurable (e.g., based on `isSystemInDarkTheme()` on a dark map). Similarly, the `DisappearingScaleBar` animations can be configured.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Box(Modifier.fillMaxSize()) {
             .align(Alignment.TopStart),
         cameraPositionState = cameraPositionState
     )
-}
+} 
 ```
 
 The colors of the text, line, and shadow are also all configurable (e.g., based on `isSystemInDarkTheme()` on a dark map). Similarly, the `DisappearingScaleBar` animations can be configured.


### PR DESCRIPTION
This PR makes a small improvement to the readme documentation, showing a fuller example on how to use `ScaleBar` and `DisappearingScaleBar`.

I made the mistake of using these composables inside `GoogleMap`, causing the crash encountered in https://github.com/googlemaps/android-maps-compose/issues/335. The idea is this change makes it less likely others would do the same.

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #335 
