### PR TITLE
fix: fixed issue when multiple marker managers have been added, for instance in multiple clustering

### DIFF
--- a/app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
@@ -176,6 +176,7 @@ fun GoogleMapView(
                 onClick = markerClick
             )
             MarkerComposable(
+                title = "Marker Composable",
                 keys = arrayOf("singapore4"),
                 state = singapore4State,
                 onClick = markerClick,

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -57,7 +57,6 @@ public fun <T : ClusterItem> Clustering(
     val clusterManager = rememberClusterManager(clusterContent, clusterItemContent) ?: return
     ResetMapListeners(clusterManager)
     SideEffect {
-        clusterManager.clearItems()
         clusterManager.setOnClusterClickListener(onClusterClick)
         clusterManager.setOnClusterItemClickListener(onClusterItemClick)
         clusterManager.setOnClusterItemInfoWindowClickListener(onClusterItemInfoWindowClick)

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -57,7 +57,7 @@ public fun <T : ClusterItem> Clustering(
     val clusterManager = rememberClusterManager(clusterContent, clusterItemContent) ?: return
     ResetMapListeners(clusterManager)
     SideEffect {
-      //  clusterManager.clearItems()
+        clusterManager.clearItems()
         clusterManager.setOnClusterClickListener(onClusterClick)
         clusterManager.setOnClusterItemClickListener(onClusterItemClick)
         clusterManager.setOnClusterItemInfoWindowClickListener(onClusterItemInfoWindowClick)

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.launch
  * @param clusterContent an optional Composable that is rendered for each [Cluster].
  * @param clusterItemContent an optional Composable that is rendered for each non-clustered item.
  */
+
 @Composable
 @GoogleMapComposable
 @MapsComposeExperimentalApi
@@ -52,18 +53,19 @@ public fun <T : ClusterItem> Clustering(
     clusterContent: @[UiComposable Composable] ((Cluster<T>) -> Unit)? = null,
     clusterItemContent: @[UiComposable Composable] ((T) -> Unit)? = null,
 ) {
-    val clusterManager = rememberClusterManager(clusterContent, clusterItemContent) ?: return
 
+    val clusterManager = rememberClusterManager(clusterContent, clusterItemContent) ?: return
     ResetMapListeners(clusterManager)
     SideEffect {
+      //  clusterManager.clearItems()
         clusterManager.setOnClusterClickListener(onClusterClick)
         clusterManager.setOnClusterItemClickListener(onClusterItemClick)
         clusterManager.setOnClusterItemInfoWindowClickListener(onClusterItemInfoWindowClick)
         clusterManager.setOnClusterItemInfoWindowLongClickListener(onClusterItemInfoWindowLongClick)
     }
     InputHandler(
-        onMarkerClick = clusterManager::onMarkerClick,
-        onInfoWindowClick = clusterManager::onInfoWindowClick,
+        onMarkerClick = clusterManager.markerManager::onMarkerClick,
+        onInfoWindowClick = clusterManager.markerManager::onInfoWindowClick,
         onInfoWindowLongClick = clusterManager.markerManager::onInfoWindowLongClick,
         onMarkerDrag = clusterManager.markerManager::onMarkerDrag,
         onMarkerDragEnd = clusterManager.markerManager::onMarkerDragEnd,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapApplier.kt
@@ -72,61 +72,69 @@ internal class MapApplier(
         map.setOnCircleClickListener { circle ->
             decorations.findInputCallback<CircleNode, Circle, Unit>(
                 nodeMatchPredicate = { it.circle == circle },
+                marker = circle,
                 nodeInputCallback = { onCircleClick },
                 inputHandlerCallback = { onCircleClick }
-            )?.invoke(circle)
+            )
         }
         map.setOnGroundOverlayClickListener { groundOverlay ->
             decorations.findInputCallback<GroundOverlayNode, GroundOverlay, Unit>(
                 nodeMatchPredicate = { it.groundOverlay == groundOverlay },
                 nodeInputCallback = { onGroundOverlayClick },
+                marker = groundOverlay,
                 inputHandlerCallback = { onGroundOverlayClick }
-            )?.invoke(groundOverlay)
+            )
         }
         map.setOnPolygonClickListener { polygon ->
             decorations.findInputCallback<PolygonNode, Polygon, Unit>(
                 nodeMatchPredicate = { it.polygon == polygon },
                 nodeInputCallback = { onPolygonClick },
+                marker = polygon,
                 inputHandlerCallback = { onPolygonClick }
-            )?.invoke(polygon)
+            )
         }
         map.setOnPolylineClickListener { polyline ->
             decorations.findInputCallback<PolylineNode, Polyline, Unit>(
                 nodeMatchPredicate = { it.polyline == polyline },
                 nodeInputCallback = { onPolylineClick },
+                marker = polyline,
                 inputHandlerCallback = { onPolylineClick }
-            )?.invoke(polyline)
+            )
         }
 
         // Marker
         map.setOnMarkerClickListener { marker ->
             decorations.findInputCallback<MarkerNode, Marker, Boolean>(
                 nodeMatchPredicate = { it.marker == marker },
+                marker = marker,
                 nodeInputCallback = { onMarkerClick },
                 inputHandlerCallback = { onMarkerClick }
-            )?.invoke(marker)
+            )
                 ?: false
         }
         map.setOnInfoWindowClickListener { marker ->
             decorations.findInputCallback<MarkerNode, Marker, Unit>(
                 nodeMatchPredicate = { it.marker == marker },
+                marker = marker,
                 nodeInputCallback = { onInfoWindowClick },
                 inputHandlerCallback = { onInfoWindowClick }
-            )?.invoke(marker)
+            )
         }
         map.setOnInfoWindowCloseListener { marker ->
             decorations.findInputCallback<MarkerNode, Marker, Unit>(
                 nodeMatchPredicate = { it.marker == marker },
+                marker = marker,
                 nodeInputCallback = { onInfoWindowClose },
                 inputHandlerCallback = { onInfoWindowClose }
-            )?.invoke(marker)
+            )
         }
         map.setOnInfoWindowLongClickListener { marker ->
             decorations.findInputCallback<MarkerNode, Marker, Unit>(
                 nodeMatchPredicate = { it.marker == marker },
+                marker = marker,
                 nodeInputCallback = { onInfoWindowLongClick },
                 inputHandlerCallback = { onInfoWindowLongClick }
-            )?.invoke(marker)
+            )
         }
         map.setOnMarkerDragListener(object : GoogleMap.OnMarkerDragListener {
             override fun onMarkerDrag(marker: Marker) {
@@ -138,13 +146,15 @@ internal class MapApplier(
                             markerState.dragState = DragState.DRAG
                         }
                     },
+                    marker = marker,
                     inputHandlerCallback = { onMarkerDrag }
-                )?.invoke(marker)
+                )
             }
 
             override fun onMarkerDragEnd(marker: Marker) {
                 decorations.findInputCallback<MarkerNode, Marker, Unit>(
                     nodeMatchPredicate = { it.marker == marker },
+                    marker = marker,
                     nodeInputCallback = {
                         {
                             markerState.position = it.position
@@ -152,12 +162,13 @@ internal class MapApplier(
                         }
                     },
                     inputHandlerCallback = { onMarkerDragEnd }
-                )?.invoke(marker)
+                )
             }
 
             override fun onMarkerDragStart(marker: Marker) {
                 decorations.findInputCallback<MarkerNode, Marker, Unit>(
                     nodeMatchPredicate = { it.marker == marker },
+                    marker = marker,
                     nodeInputCallback = {
                         {
                             markerState.position = it.position
@@ -165,7 +176,7 @@ internal class MapApplier(
                         }
                     },
                     inputHandlerCallback = { onMarkerDragStart }
-                )?.invoke(marker)
+                )
             }
         })
         map.setInfoWindowAdapter(
@@ -181,25 +192,29 @@ internal class MapApplier(
 }
 
 /**
- * General pattern for handling input:
- * Find the node that belongs to the clicked item.
- * If there is none, default to the first InputHandlerNode.
+ * General pattern for handling input. This finds the node that belongs to the clicked item, and executes the callback.
+ *
  * If there is none, don't handle.
  */
 private inline fun <reified NodeT : MapNode, I, O> Iterable<MapNode>.findInputCallback(
     nodeMatchPredicate: (NodeT) -> Boolean,
     nodeInputCallback: NodeT.() -> ((I) -> O)?,
+    marker : I,
     inputHandlerCallback: InputHandlerNode.() -> ((I) -> O)?,
-): ((I) -> O)? {
-    var callback: ((I) -> O)? = null
+): Boolean {
+    var callback: ((I) -> O)?
     for (item in this) {
         if (item is NodeT && nodeMatchPredicate(item)) {
             // Found a matching node
-            return nodeInputCallback(item)
+            nodeInputCallback(item)?.invoke(marker)
+            return true
         } else if (item is InputHandlerNode) {
             // Found an input handler, but keep looking for matching nodes
             callback = inputHandlerCallback(item)
+            if (callback?.invoke(marker) == true) {
+                return true
+            }
         }
     }
-    return callback
+    return false
 }


### PR DESCRIPTION
The following PR fixes an issue when multiple MarkerManagers are added (for instance, when we are adding multiple clusters), and only the last one is being triggered.

This has been solved by moving the execution of the invoke function within the reified `findInputCallback` function. The function will execute the callback click listener when we found a matching node or an input handler.

--
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #294 and eventually #394
