### PR TITLE
fix: fixed test for MapInColumn

### DIFF
--- a/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
+++ b/app/src/androidTest/java/com/google/maps/android/compose/MapInColumnTests.kt
@@ -39,7 +39,7 @@ class MapInColumnTests {
     private val startingPosition = LatLng(1.23, 4.56)
     private lateinit var cameraPositionState: CameraPositionState
 
-    private fun initMap(content: @Composable () -> Unit = {}) {
+    private fun initMap() {
         check(hasValidApiKey) { "Maps API key not specified" }
         val countDownLatch = CountDownLatch(1)
         composeTestRule.setContent {
@@ -134,7 +134,7 @@ class MapInColumnTests {
     fun testPanMapUp_MapCameraChangesColumnDoesNotScroll() {
         initMap()
         //Swipe the map up
-        composeTestRule.onNodeWithTag("Map").performTouchInput { swipeUp() }
+        composeTestRule.onAllNodesWithTag("Map").onFirst().performTouchInput { swipeUp() }
         composeTestRule.waitForIdle()
 
         //Make sure that the map changed (i.e., we can scroll the map in the column)


### PR DESCRIPTION
Sometimes the map is recomposing, and two equal ones appear on the tree node.

This PR fixes the issue but selecting the first one.

- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #411 🦕
