### PR TITLE
chore: update semantic-release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,8 +1,10 @@
 branches:
   - main
 plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
   - - "@google/semantic-release-replace-plugin"
     - replacements:
         - files:


### PR DESCRIPTION
Found that release flow [doesn't trigger a release](https://github.com/semantic-release/semantic-release/issues/2339) based on using `!` to indicate breaking changes in commit messages. Specify `conventionalcommit` message per [workaround](https://github.com/semantic-release/semantic-release/issues/2339#issuecomment-1451987883).
