### PR TITLE
chore: updating JDK in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
     - uses: gradle/wrapper-validation-action@v1.0.4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2.3.1
+      with:
+        java-version: '17'
+        distribution: 'adopt'
     - name: Create .gpg key
       run: |
         echo $GPG_KEY_ARMOR | base64 --decode > ./release.asc


### PR DESCRIPTION
This PR updates the JDK in the release workflow. This should fix the following failing action: https://github.com/googlemaps/android-maps-compose/actions/runs/6391132902

