### PR TITLE
feat: Implemented so that ClusterManager#setAlgorithm can be use.

### DIFF
--- a/app/src/main/java/com/google/maps/android/compose/MarkerClusteringActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MarkerClusteringActivity.kt
@@ -5,16 +5,29 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,6 +39,8 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.clustering.ClusterItem
 import com.google.maps.android.compose.clustering.Clustering
+import com.google.maps.android.compose.clustering.rememberClusterManager
+import com.google.maps.android.compose.clustering.rememberClusterRenderer
 import kotlin.random.Random
 
 private val TAG = MarkerClusteringActivity::class.simpleName
@@ -54,51 +69,37 @@ fun GoogleMapClustering() {
     GoogleMapClustering(items = items)
 }
 
-@OptIn(MapsComposeExperimentalApi::class)
 @Composable
 fun GoogleMapClustering(items: List<MyItem>) {
+    var clusteringType by remember {
+        mutableStateOf(ClusteringType.Default)
+    }
     GoogleMap(
         modifier = Modifier.fillMaxSize(),
         cameraPositionState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(singapore, 6f)
         }
     ) {
-        Clustering(
-            items = items,
-            // Optional: Handle clicks on clusters, cluster items, and cluster item info windows
-            onClusterClick = {
-                Log.d(TAG, "Cluster clicked! $it")
-                false
-            },
-            onClusterItemClick = {
-                Log.d(TAG, "Cluster item clicked! $it")
-                false
-            },
-            onClusterItemInfoWindowClick = {
-                Log.d(TAG, "Cluster item info window clicked! $it")
-            },
-            // Optional: Custom rendering for clusters
-            clusterContent = { cluster ->
-                Surface(
-                    Modifier.size(40.dp),
-                    shape = CircleShape,
-                    color = Color.Blue,
-                    contentColor = Color.White,
-                    border = BorderStroke(1.dp, Color.White)
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Text(
-                            "%,d".format(cluster.size),
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Black,
-                            textAlign = TextAlign.Center
-                        )
-                    }
-                }
-            },
-            // Optional: Custom rendering for non-clustered items
-            clusterItemContent = null
-        )
+        when (clusteringType) {
+            ClusteringType.Default -> {
+                DefaultClustering(
+                    items = items,
+                )
+            }
+
+            ClusteringType.CustomUi -> {
+                CustomUiClustering(
+                    items = items,
+                )
+            }
+
+            ClusteringType.CustomRenderer -> {
+                CustomRendererClustering(
+                    items = items,
+                )
+            }
+        }
+
         MarkerInfoWindow(
             state = rememberMarkerState(position = singapore),
             onClick = {
@@ -107,6 +108,179 @@ fun GoogleMapClustering(items: List<MyItem>) {
             }
         )
     }
+
+    ClusteringTypeControls(
+        onClusteringTypeClick = {
+            clusteringType = it
+        },
+    )
+}
+
+@OptIn(MapsComposeExperimentalApi::class)
+@Composable
+private fun DefaultClustering(items: List<MyItem>) {
+    Clustering(
+        items = items,
+        // Optional: Handle clicks on clusters, cluster items, and cluster item info windows
+        onClusterClick = {
+            Log.d(TAG, "Cluster clicked! $it")
+            false
+        },
+        onClusterItemClick = {
+            Log.d(TAG, "Cluster item clicked! $it")
+            false
+        },
+        onClusterItemInfoWindowClick = {
+            Log.d(TAG, "Cluster item info window clicked! $it")
+        },
+        // Optional: Custom rendering for non-clustered items
+        clusterItemContent = null
+    )
+}
+
+@OptIn(MapsComposeExperimentalApi::class)
+@Composable
+private fun CustomUiClustering(items: List<MyItem>) {
+    Clustering(
+        items = items,
+        // Optional: Handle clicks on clusters, cluster items, and cluster item info windows
+        onClusterClick = {
+            Log.d(TAG, "Cluster clicked! $it")
+            false
+        },
+        onClusterItemClick = {
+            Log.d(TAG, "Cluster item clicked! $it")
+            false
+        },
+        onClusterItemInfoWindowClick = {
+            Log.d(TAG, "Cluster item info window clicked! $it")
+        },
+        // Optional: Custom rendering for clusters
+        clusterContent = { cluster ->
+            CircleContent(
+                modifier = Modifier.size(40.dp),
+                text = "%,d".format(cluster.size),
+                color = Color.Blue,
+            )
+        },
+        // Optional: Custom rendering for non-clustered items
+        clusterItemContent = null
+    )
+}
+
+@OptIn(MapsComposeExperimentalApi::class)
+@Composable
+fun CustomRendererClustering(items: List<MyItem>) {
+    val clusterManager = rememberClusterManager<MyItem>()
+    val renderer = rememberClusterRenderer(
+        clusterContent = { cluster ->
+            CircleContent(
+                modifier = Modifier.size(40.dp),
+                text = "%,d".format(cluster.size),
+                color = Color.Green,
+            )
+        },
+        clusterItemContent = {
+            CircleContent(
+                modifier = Modifier.size(20.dp),
+                text = "",
+                color = Color.Green,
+            )
+        },
+        clusterManager = clusterManager,
+    )
+    SideEffect {
+        clusterManager ?: return@SideEffect
+        clusterManager.setOnClusterClickListener {
+            Log.d(TAG, "Cluster clicked! $it")
+            false
+        }
+        clusterManager.setOnClusterItemClickListener {
+            Log.d(TAG, "Cluster item clicked! $it")
+            false
+        }
+        clusterManager.setOnClusterItemInfoWindowClickListener {
+            Log.d(TAG, "Cluster item info window clicked! $it")
+        }
+    }
+    LaunchedEffect(clusterManager, renderer) {
+        clusterManager?.renderer = renderer ?: return@LaunchedEffect
+    }
+
+    if (clusterManager != null) {
+        Clustering(
+            items = items,
+            clusterManager = clusterManager,
+        )
+    }
+}
+
+@Composable
+private fun CircleContent(
+    color: Color,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier,
+        shape = CircleShape,
+        color = color,
+        contentColor = Color.White,
+        border = BorderStroke(1.dp, Color.White)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Black,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClusteringTypeControls(
+    onClusteringTypeClick: (ClusteringType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .horizontalScroll(state = ScrollState(0)),
+        horizontalArrangement = Arrangement.Start
+    ) {
+        ClusteringType.entries.forEach {
+            MapButton(
+                text = when (it) {
+                    ClusteringType.Default -> "Default"
+                    ClusteringType.CustomUi -> "Custom UI"
+                    ClusteringType.CustomRenderer -> "Custom Renderer"
+                },
+                onClick = { onClusteringTypeClick(it) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun MapButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Button(
+        modifier = modifier.padding(4.dp),
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = MaterialTheme.colors.onPrimary,
+            contentColor = MaterialTheme.colors.primary
+        ),
+        onClick = onClick
+    ) {
+        Text(text = text, style = MaterialTheme.typography.body1)
+    }
+}
+
+private enum class ClusteringType {
+    Default,
+    CustomUi,
+    CustomRenderer,
 }
 
 data class MyItem(

--- a/app/src/main/java/com/google/maps/android/compose/MarkerClusteringActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MarkerClusteringActivity.kt
@@ -203,8 +203,10 @@ fun CustomRendererClustering(items: List<MyItem>) {
             Log.d(TAG, "Cluster item info window clicked! $it")
         }
     }
-    LaunchedEffect(clusterManager, renderer) {
-        clusterManager?.renderer = renderer ?: return@LaunchedEffect
+    SideEffect {
+        if (clusterManager?.renderer != renderer) {
+            clusterManager?.renderer = renderer ?: return@SideEffect
+        }
     }
 
     if (clusterManager != null) {

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -189,9 +189,9 @@ public fun <T : ClusterItem> Clustering(
  * @param clusterContent an optional Composable that is rendered for each [Cluster].
  * @param clusterItemContent an optional Composable that is rendered for each non-clustered item.
  */
-@OptIn(MapsComposeExperimentalApi::class)
 @Composable
 @GoogleMapComposable
+@MapsComposeExperimentalApi
 public fun <T : ClusterItem> rememberClusterRenderer(
     clusterContent: @Composable ((Cluster<T>) -> Unit)?,
     clusterItemContent: @Composable ((T) -> Unit)?,
@@ -231,9 +231,9 @@ public fun <T : ClusterItem> rememberClusterRenderer(
     return clusterRendererState.value
 }
 
-@OptIn(MapsComposeExperimentalApi::class)
-@GoogleMapComposable
 @Composable
+@GoogleMapComposable
+@MapsComposeExperimentalApi
 public fun <T : ClusterItem> rememberClusterManager(): ClusterManager<T>? {
     val context = LocalContext.current
     val clusterManagerState: MutableState<ClusterManager<T>?> = remember { mutableStateOf(null) }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -123,23 +123,27 @@ public fun <T : ClusterItem> Clustering(
     clusterItemContent: @[UiComposable Composable] ((T) -> Unit)? = null,
 ) {
     val clusterManager = rememberClusterManager<T>()
-        ?: return
     val renderer = rememberClusterRenderer(clusterContent, clusterItemContent, clusterManager)
-    LaunchedEffect(clusterManager, renderer) {
-        clusterManager.renderer = renderer ?: return@LaunchedEffect
+    SideEffect {
+        if (clusterManager?.renderer != renderer) {
+            clusterManager?.renderer = renderer ?: return@SideEffect
+        }
     }
 
     SideEffect {
+        clusterManager ?: return@SideEffect
         clusterManager.setOnClusterClickListener(onClusterClick)
         clusterManager.setOnClusterItemClickListener(onClusterItemClick)
         clusterManager.setOnClusterItemInfoWindowClickListener(onClusterItemInfoWindowClick)
         clusterManager.setOnClusterItemInfoWindowLongClickListener(onClusterItemInfoWindowLongClick)
     }
 
-    Clustering(
-        items = items,
-        clusterManager = clusterManager,
-    )
+    if (clusterManager != null) {
+        Clustering(
+            items = items,
+            clusterManager = clusterManager,
+        )
+    }
 }
 
 /**

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -3,6 +3,7 @@ package com.google.maps.android.compose.clustering
 import android.os.Handler
 import android.os.Looper
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.SideEffect
@@ -180,6 +181,12 @@ public fun <T : ClusterItem> Clustering(
                 clusterManager.addItems(items)
                 clusterManager.cluster()
             }
+    }
+    DisposableEffect(itemsState) {
+        onDispose {
+            clusterManager.clearItems()
+            clusterManager.cluster()
+        }
     }
 }
 

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -190,6 +190,25 @@ public fun <T : ClusterItem> Clustering(
     }
 }
 
+
+@Composable
+@GoogleMapComposable
+@MapsComposeExperimentalApi
+public fun <T : ClusterItem> rememberClusterRenderer(
+    clusterManager: ClusterManager<T>?,
+): ClusterRenderer<T>? {
+    val context = LocalContext.current
+    val clusterRendererState: MutableState<ClusterRenderer<T>?> = remember { mutableStateOf(null) }
+
+    clusterManager ?: return null
+    MapEffect(context) { map ->
+        val renderer = DefaultClusterRenderer(context, map, clusterManager)
+        clusterRendererState.value = renderer
+    }
+
+    return clusterRendererState.value
+}
+
 /**
  * Default Renderer for drawing Composable.
  *
@@ -212,28 +231,16 @@ public fun <T : ClusterItem> rememberClusterRenderer(
 
     clusterManager ?: return null
     MapEffect(context) { map ->
-        launch {
-            snapshotFlow {
-                clusterContentState.value != null || clusterItemContentState.value != null
-            }
-                .collect { hasCustomContent ->
-                    val renderer = if (hasCustomContent) {
-                        ComposeUiClusterRenderer(
-                            context,
-                            scope = this,
-                            map,
-                            clusterManager,
-                            viewRendererState,
-                            clusterContentState,
-                            clusterItemContentState,
-                        )
-                    } else {
-                        DefaultClusterRenderer(context, map, clusterManager)
-                    }
-                    clusterRendererState.value = renderer
-                }
-        }
-
+        val renderer = ComposeUiClusterRenderer(
+            context,
+            scope = this,
+            map,
+            clusterManager,
+            viewRendererState,
+            clusterContentState,
+            clusterItemContentState,
+        )
+        clusterRendererState.value = renderer
     }
     return clusterRendererState.value
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -52,18 +52,21 @@ import kotlinx.coroutines.launch
         expression = """
             val clusterManager = rememberClusterManager<T>()
             LaunchedEffect(clusterManager, clusterRenderer) {
-                clusterManager.renderer = clusterRenderer
+                clusterManager?.renderer = clusterRenderer
             }
             SideEffect {
+                clusterManager ?: return@SideEffect
                 clusterManager.setOnClusterClickListener(onClusterClick)
                 clusterManager.setOnClusterItemClickListener(onClusterItemClick)
                 clusterManager.setOnClusterItemInfoWindowClickListener(onClusterItemInfoWindowClick)
                 clusterManager.setOnClusterItemInfoWindowLongClickListener(onClusterItemInfoWindowLongClick)
             }
-            Clustering(
-                items = items,
-                clusterManager = clusterManager,
-            )
+            if (clusterManager != null) {
+                Clustering(
+                    items = items,
+                    clusterManager = clusterManager,
+                )
+            }
         """,
         imports = [
             "com.google.maps.android.compose.clustering.Clustering",


### PR DESCRIPTION
Existing problems
- ClusterManager#setAlgorithm is not available.
- clusterContent and clusterItemContent are not used when clusterRenderer is specified.

As described in the Issue, we thought it would be less confusing for users to separate the low-level API and the high-level API.

Clustering Composable Function that takes a clusterManager as an argument, memberClusterRenderer and memberClusterManager are implemented and make public.
The existing Clustering Composable Function calls the low-level Clustering Composable Function.

-----
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #420 🦕
