### PR TITLE
feat!: setting the custom location button via sample

### DIFF
--- a/app/src/main/java/com/google/maps/android/compose/CustomControlsActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/CustomControlsActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
+
 class CustomControlsActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,7 +47,7 @@ class CustomControlsActivity : ComponentActivity() {
 
         setContent {
             var isMapLoaded by remember { mutableStateOf(false) }
-            val mapProperties by remember { mutableStateOf(MapProperties(isMyLocationEnabled = true)) }
+            val uiSettings by remember { mutableStateOf(MapUiSettings(myLocationButtonEnabled = false)) }
             // Observing and controlling the camera's state can be done with a CameraPositionState
             val cameraPositionState = rememberCameraPositionState {
                 position = defaultCameraPosition
@@ -59,17 +60,16 @@ class CustomControlsActivity : ComponentActivity() {
                     onMapLoaded = {
                         isMapLoaded = true
                     },
-
-                    myLocationButton = {
-                        MapButton(
-                            "This is a custom location button",
-                            onClick = {
-                                Toast.makeText(
-                                    this@CustomControlsActivity,
-                                    "Click on my location",
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            })
+                    uiSettings = uiSettings,
+                )
+                MapButton(
+                    "This is a custom location button",
+                    onClick = {
+                        Toast.makeText(
+                            this@CustomControlsActivity,
+                            "Click on my location",
+                            Toast.LENGTH_SHORT
+                        ).show()
                     })
 
                 if (!isMapLoaded) {

--- a/app/src/main/java/com/google/maps/android/compose/CustomControlsActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/CustomControlsActivity.kt
@@ -47,6 +47,8 @@ class CustomControlsActivity : ComponentActivity() {
 
         setContent {
             var isMapLoaded by remember { mutableStateOf(false) }
+            // This needs to be manually deactivated to avoid having a custom and the native
+            // location button
             val uiSettings by remember { mutableStateOf(MapUiSettings(myLocationButtonEnabled = false)) }
             // Observing and controlling the camera's state can be done with a CameraPositionState
             val cameraPositionState = rememberCameraPositionState {

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.awaitCancellation
 @Composable
 public fun GoogleMap(
     modifier: Modifier = Modifier,
+    currentLocationModifier : Modifier = Modifier,
     cameraPositionState: CameraPositionState = rememberCameraPositionState(),
     contentDescription: String? = null,
     googleMapOptionsFactory: () -> GoogleMapOptions = { GoogleMapOptions() },
@@ -119,11 +120,13 @@ public fun GoogleMap(
     val currentContentPadding by rememberUpdatedState(contentPadding)
 
     // If we pass a custom location button, the native one is deactivated.
-    val currentUiSettings by rememberUpdatedState(if (myLocationButton != null) {
-        uiSettings.copy(myLocationButtonEnabled = false)
-    } else {
-        uiSettings
-    })
+    val currentUiSettings by rememberUpdatedState(
+        if (myLocationButton != null) {
+            uiSettings.copy(myLocationButtonEnabled = false)
+        } else {
+            uiSettings
+        }
+    )
     val currentMapProperties by rememberUpdatedState(properties)
 
     val parentComposition = rememberCompositionContext()
@@ -150,10 +153,11 @@ public fun GoogleMap(
             }
         }
     }
-    Row(modifier = modifier) {
-        currentLocation?.invoke()
+    currentLocation?.let {
+        Row(modifier = currentLocationModifier) {
+            currentLocation?.invoke()
+        }
     }
-
 }
 
 internal suspend inline fun disposingComposition(factory: () -> Composition) {
@@ -217,6 +221,7 @@ private fun MapView.lifecycleObserver(previousState: MutableState<Lifecycle.Even
                     this.onCreate(Bundle())
                 }
             }
+
             Lifecycle.Event.ON_START -> this.onStart()
             Lifecycle.Event.ON_RESUME -> this.onResume()
             Lifecycle.Event.ON_PAUSE -> this.onPause()
@@ -224,6 +229,7 @@ private fun MapView.lifecycleObserver(previousState: MutableState<Lifecycle.Even
             Lifecycle.Event.ON_DESTROY -> {
                 //handled in onDispose
             }
+
             else -> throw IllegalStateException()
         }
         previousState.value = event

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -20,7 +20,6 @@ import android.location.Location
 import android.os.Bundle
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
@@ -74,7 +73,6 @@ import kotlinx.coroutines.awaitCancellation
 @Composable
 public fun GoogleMap(
     modifier: Modifier = Modifier,
-    currentLocationModifier : Modifier = Modifier,
     cameraPositionState: CameraPositionState = rememberCameraPositionState(),
     contentDescription: String? = null,
     googleMapOptionsFactory: () -> GoogleMapOptions = { GoogleMapOptions() },
@@ -89,7 +87,6 @@ public fun GoogleMap(
     onMyLocationClick: ((Location) -> Unit)? = null,
     onPOIClick: ((PointOfInterest) -> Unit)? = null,
     contentPadding: PaddingValues = NoPadding,
-    myLocationButton: (@Composable @GoogleMapComposable () -> Unit)? = null,
     content: (@Composable @GoogleMapComposable () -> Unit)? = null,
 ) {
     // When in preview, early return a Box with the received modifier preserving layout
@@ -120,18 +117,11 @@ public fun GoogleMap(
     val currentContentPadding by rememberUpdatedState(contentPadding)
 
     // If we pass a custom location button, the native one is deactivated.
-    val currentUiSettings by rememberUpdatedState(
-        if (myLocationButton != null) {
-            uiSettings.copy(myLocationButtonEnabled = false)
-        } else {
-            uiSettings
-        }
-    )
+    val currentUiSettings by rememberUpdatedState(uiSettings)
     val currentMapProperties by rememberUpdatedState(properties)
 
     val parentComposition = rememberCompositionContext()
     val currentContent by rememberUpdatedState(content)
-    val currentLocation by rememberUpdatedState(myLocationButton)
 
     LaunchedEffect(Unit) {
         disposingComposition {
@@ -151,11 +141,6 @@ public fun GoogleMap(
                     currentContent?.invoke()
                 }
             }
-        }
-    }
-    currentLocation?.let {
-        Row(modifier = currentLocationModifier) {
-            currentLocation?.invoke()
         }
     }
 }
@@ -221,7 +206,6 @@ private fun MapView.lifecycleObserver(previousState: MutableState<Lifecycle.Even
                     this.onCreate(Bundle())
                 }
             }
-
             Lifecycle.Event.ON_START -> this.onStart()
             Lifecycle.Event.ON_RESUME -> this.onResume()
             Lifecycle.Event.ON_PAUSE -> this.onPause()
@@ -229,7 +213,6 @@ private fun MapView.lifecycleObserver(previousState: MutableState<Lifecycle.Even
             Lifecycle.Event.ON_DESTROY -> {
                 //handled in onDispose
             }
-
             else -> throw IllegalStateException()
         }
         previousState.value = event


### PR DESCRIPTION
Update: this PR moves the custom location to the sample instead of managing it via the GoogleMap.

~~The following PR fixes an issue when a Modifier was set for GoogleMaps. This PR introduces a custom Modifier for the custom location row in the map, and adds this one only when a custom location has been added.~~

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #427
