### PR TITLE
docs: added recomposition sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,30 @@ GoogleMap(
 </details>
 
 <details>
+  <summary>Recomposing elements</summary>
+
+### Recomposing elements
+
+Markers and other elements need to be recomposed in the screen. To achieve recomposition you need to 
+have a mutable state variable:
+
+```kotlin
+var location by remember { mutableStateOf(singapore) }
+val singaporeState = MarkerState(position = location)
+
+//...
+
+Marker(
+    state = singaporeState,
+    title = "Marker in Singapore",
+    onClick = markerClick
+)
+```
+
+In the example above, when `location` changes the recomposition will be triggered. 
+
+</details>
+<details>
   <summary>Customizing a marker's info window</summary>
 
 ### Customizing a marker's info window

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2021 Google LLC
+ Copyright 2023 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -65,6 +65,9 @@
         android:exported="false"/>
     <activity
         android:name=".AccessibilityActivity"
+        android:exported="false"/>
+    <activity
+        android:name=".RecompositionActivity"
         android:exported="false"/>
 
     <!-- Used by createComponentActivity() for unit testing -->

--- a/app/src/main/java/com/google/maps/android/compose/MainActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/MainActivity.kt
@@ -134,6 +134,13 @@ class MainActivity : ComponentActivity() {
                             }) {
                             Text(getString(R.string.accessibility_button))
                         }
+                        Spacer(modifier = Modifier.padding(5.dp))
+                        Button(
+                            onClick = {
+                                context.startActivity(Intent(context, RecompositionActivity::class.java))
+                            }) {
+                            Text(getString(R.string.recomposition_activity))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/google/maps/android/compose/RecompositionActivity.kt
+++ b/app/src/main/java/com/google/maps/android/compose/RecompositionActivity.kt
@@ -1,0 +1,118 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.maps.android.compose
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.google.android.gms.maps.model.Marker
+import com.google.maps.android.compose.theme.MapsComposeSampleTheme
+import kotlin.random.Random
+
+private const val TAG = "RecompositionActivity"
+
+/**
+ * This is a sample activity showcasing how the recomposition works. The location is changed
+ * every time we click on the button, and the marker gets updated (removed and added in a new
+ * location)
+ */
+class RecompositionActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            val cameraPositionState = rememberCameraPositionState {
+                position = defaultCameraPosition
+            }
+            Box(Modifier.fillMaxSize()) {
+                MapsComposeSampleTheme {
+                    GoogleMapView(
+                        modifier = Modifier.matchParentSize(),
+                        cameraPositionState = cameraPositionState
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun GoogleMapView(
+        modifier: Modifier = Modifier,
+        cameraPositionState: CameraPositionState = rememberCameraPositionState(),
+        content: @Composable () -> Unit = {},
+    ) {
+        var location by remember { mutableStateOf(singapore) }
+        val singaporeState = MarkerState(position = location)
+
+        val uiSettings by remember { mutableStateOf(MapUiSettings(compassEnabled = false)) }
+        val mapProperties by remember {
+            mutableStateOf(MapProperties(mapType = MapType.NORMAL))
+        }
+
+        val mapVisible by remember { mutableStateOf(true) }
+        if (mapVisible) {
+            GoogleMap(
+                modifier = modifier,
+                cameraPositionState = cameraPositionState,
+                properties = mapProperties,
+                uiSettings = uiSettings,
+                onPOIClick = {
+                    Log.d(TAG, "POI clicked: ${it.name}")
+                }
+            ) {
+                val markerClick: (Marker) -> Boolean = {
+                    Log.d(TAG, "${it.title} was clicked")
+                    cameraPositionState.projection?.let { projection ->
+                        Log.d(TAG, "The current projection is: $projection")
+                    }
+                    false
+                }
+
+                Marker(
+                    state = singaporeState,
+                    title = "Marker in Singapore",
+                    onClick = markerClick
+                )
+
+                content()
+            }
+            Column {
+                Button(onClick = {
+                    val randomValue = Random.nextInt(3)
+                    location = when (randomValue) {
+                        0 -> singapore
+                        1 -> singapore2
+                        2 -> singapore3
+                        else -> singapore
+                    }
+                }) {
+                    Text("Change Location")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright 2021 Google LLC
+ Copyright 2023 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
   <string name="marker_clustering_activity">Marker Clustering</string>
   <string name="location_tracking_activity">Location Tracking</string>
   <string name="scale_bar_activity">Scale Bar</string>
+  <string name="recomposition_activity">Recomposition Map</string>
   <string name="street_view">Street View</string>
   <string name="custom_location_button">Custom Location Button</string>
   <string name="accessibility_button">Accessibility</string>


### PR DESCRIPTION
This PR adds a recomposition sample, to showcase how to remove or add markers using a remember variable and recomposition.

https://github.com/googlemaps/android-maps-compose/assets/903097/098a6a95-4a24-45e0-b5e8-1acfa3b144ce

---


Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #442, #91, #403 🦕
