### PR TITLE
fix: expose ktx classes to app-level modules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     implementation libs.androidx.compose.material
     implementation libs.kotlin
     implementation libs.material
-    implementation libs.maps.ktx.std
     implementation libs.androidx.compose.ui.preview.tooling
     debugImplementation libs.androidx.compose.ui.tooling
 

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -42,8 +42,8 @@ dependencies {
     implementation libs.androidx.compose.material
     implementation libs.androidx.core
     implementation libs.kotlin
-    implementation libs.maps.ktx.std
-    implementation libs.maps.ktx.utils
+    api libs.maps.ktx.std
+    api libs.maps.ktx.utils
 
     testImplementation libs.test.junit
     androidTestImplementation platform(libs.androidx.compose.bom)

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation libs.androidx.core
     implementation libs.androidx.compose.foundation
     implementation libs.kotlin
-    implementation libs.maps.ktx.std
+    api libs.maps.ktx.std
 
     testImplementation libs.test.junit
 


### PR DESCRIPTION
Switch from implementation to api dependency to expose the classes from maps-ktx in maps-compose.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #450 🦕
