### PR TITLE
fix: add stability configuration file to the core maps-compose projec…

### DIFF
--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -31,6 +31,27 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs += '-Xexplicit-api=strict'
         freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+
+        freeCompilerArgs += [
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
+                        layout.projectDirectory.file('compose_compiler.conf').asFile.absolutePath
+        ]
+
+        if (findProperty("composeCompilerReports") == "true") {
+            freeCompilerArgs += [
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                            project.buildDir.absolutePath + "/compose_compiler"
+            ]
+        }
+        if (findProperty("composeCompilerMetrics") == "true") {
+            freeCompilerArgs += [
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                            project.buildDir.absolutePath + "/compose_compiler"
+            ]
+        }
     }
 }
 

--- a/maps-compose/compose_compiler.conf
+++ b/maps-compose/compose_compiler.conf
@@ -1,0 +1,7 @@
+com.google.android.gms.maps.model.BitmapDescriptor
+com.google.android.gms.maps.model.Cap
+com.google.android.gms.maps.model.LatLng
+com.google.android.gms.maps.model.LatLngBounds
+com.google.android.gms.maps.model.MapStyleOptions
+com.google.android.gms.maps.model.PatternItem
+com.google.android.gms.maps.model.PinConfig


### PR DESCRIPTION
…t. The currently configured types are all the immutable data types from com.google.android.gms.maps.model that are currently used in android-maps-compose:maps-compose. These types will now be considered @Stable by the compiler. Making immutable data types @Stable can be a more effective measure than relying on strong skipping, as stable types can use structural equality, whereas strong skipping merely relies on referential equality, as of today.

This commit also makes compose compiler report generation available via command-line options (-PcomposeCompilerMetrics=true, -PcomposeCompilerReports=true)

Fixes #152