### PR TITLE
feat!: change GoogleMap() content parameter default to {} and make content non-nullable

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -89,7 +89,7 @@ public fun GoogleMap(
     onMyLocationClick: ((Location) -> Unit)? = null,
     onPOIClick: ((PointOfInterest) -> Unit)? = null,
     contentPadding: PaddingValues = NoPadding,
-    content: (@Composable @GoogleMapComposable () -> Unit)? = null,
+    content: @Composable @GoogleMapComposable () -> Unit = {},
 ) {
     // When in preview, early return a Box with the received modifier preserving layout
     if (LocalInspectionMode.current) {
@@ -140,9 +140,8 @@ public fun GoogleMap(
 
                 CompositionLocalProvider(
                     LocalCameraPositionState provides currentCameraPositionState,
-                ) {
-                    currentContent?.invoke()
-                }
+                    currentContent
+                )
             }
         }
     }


### PR DESCRIPTION
Fixes #493