### PR TITLE
fix: Return early in rememberComposeBitmapDescriptor for invalid view size

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -200,6 +200,8 @@ public fun Marker(
 /**
  * Composable rendering the content passed as a marker.
  *
+ * This composable must have a non-zero size in both dimensions
+ *
  * @param keys unique keys representing the state of this Marker. Any changes to one of the key will
  * trigger a rendering of the content composable and thus the rendering of an updated marker.
  * @param state the [MarkerState] to be used to control or observe the marker
@@ -221,6 +223,9 @@ public fun Marker(
  * @param onInfoWindowClose a lambda invoked when the marker's info window is closed
  * @param onInfoWindowLongClick a lambda invoked when the marker's info window is long clicked
  * @param content composable lambda expression used to customize the marker's content
+ *
+ * @throws IllegalStateException if the composable is measured to have a size of zero in either
+ * dimension
  */
 @Composable
 @GoogleMapComposable

--- a/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
@@ -30,6 +30,8 @@ internal fun rememberComposeBitmapDescriptor(
     }
 }
 
+private val measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+
 private fun renderComposableToBitmapDescriptor(
     parent: ViewGroup,
     compositionContext: CompositionContext,
@@ -50,10 +52,7 @@ private fun renderComposableToBitmapDescriptor(
 
     composeView.draw(fakeCanvas)
 
-    composeView.measure(
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-    )
+    composeView.measure(measureSpec, measureSpec)
 
     if (composeView.measuredWidth == 0 || composeView.measuredHeight == 0) {
         throw IllegalStateException("The ComposeView was measured to have a width or height of " +

--- a/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
@@ -56,7 +56,7 @@ private fun renderComposableToBitmapDescriptor(
 
     if (composeView.measuredWidth == 0 || composeView.measuredHeight == 0) {
         throw IllegalStateException("The ComposeView was measured to have a width or height of " +
-                "zero. Make sure the parent and content have a non-zero size.")
+                "zero. Make sure that the content has a non-zero size.")
     }
 
     composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)

--- a/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
@@ -39,6 +39,10 @@ private fun renderComposableToBitmapDescriptor(
     val composeView =
         ComposeView(parent.context)
             .apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
                 setParentCompositionContext(compositionContext)
                 setContent(content)
             }
@@ -47,9 +51,14 @@ private fun renderComposableToBitmapDescriptor(
     composeView.draw(fakeCanvas)
 
     composeView.measure(
-        View.MeasureSpec.makeMeasureSpec(parent.width, View.MeasureSpec.AT_MOST),
-        View.MeasureSpec.makeMeasureSpec(parent.height, View.MeasureSpec.AT_MOST),
+        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
     )
+
+    if (composeView.measuredWidth == 0 || composeView.measuredHeight == 0) {
+        throw IllegalStateException("The ComposeView was measured to have a width or height of " +
+                "zero. Make sure the parent and content have a non-zero size.")
+    }
 
     composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)
 


### PR DESCRIPTION
Fixes #518  🦕

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

By returning early in the case of invalid view width/height, we can avoid the IllegalArgumentException described in issue #518.
