### PR TITLE
chore: increase java-setup version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
     - uses: gradle/actions/wrapper-validation@v3
     - name: Set up JDK 17
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: '17'
         distribution: 'adopt'


### PR DESCRIPTION
This PR updates the setup-java GitHub Action to 4.2.1, eventually fixing an issue with the release flow where the artifact doesn't get published.
