### PR TITLE
chore: updated Kotlin to 2.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
+    alias libs.plugins.compose.compiler
 }
 
 android {
@@ -22,10 +23,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
-    }
-
     buildFeatures {
         buildConfig true
         compose true
@@ -33,7 +30,7 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+        freeCompilerArgs += '-opt-in=kotlin.RequiresOptIn'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = libs.versions.kotlin.get()
-    ext.compose_compiler_version = libs.versions.composecompiler.get()
     ext.androidx_test_version = libs.versions.androidxtest.get()
     repositories {
         google()
@@ -18,6 +17,7 @@ buildscript {
 
 plugins {
     alias libs.plugins.dokka apply true
+    alias libs.plugins.compose.compiler apply false
 }
 
 ext.projectArtifactId = { project ->
@@ -124,5 +124,5 @@ subprojects { project ->
 }
 
 tasks.register('clean', Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,5 @@ signing.secretKeyRingFile=
 sonatypeUsername=
 sonatypePassword=
 
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,20 @@
 [versions]
 activitycompose = "1.9.0"
-agp = "8.4.0"
+agp = "8.4.1"
 androidxtest = "1.5.0"
-compose-bom = "2024.04.01"
-composecompiler = "1.5.11"
+compose-bom = "2024.05.00"
 coroutines = "1.7.3"
-dokka = "1.9.10"
+dokka = "1.9.20"
 espresso = "3.5.1"
 jacoco-plugin = "0.2.1"
 jacoco-tool-plugin = "0.8.7"
 junitktx = "1.1.5"
 junit = "4.13.2"
-kotlin = "1.9.23"
-material = "1.11.0"
+kotlin = "2.0.0"
+material = "1.12.0"
 mapsktx = "5.0.0"
 mapsecrets = "2.0.1"
+android-core = "1.13.1"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -25,7 +25,7 @@ androidx-compose-material = { module = "androidx.compose.material:material" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
-androidx-core = { module = "androidx.core:core-ktx", version = "1.13.0" }
+androidx-core = { module = "androidx.core:core-ktx", version = "android-core" }
 androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxtest" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
@@ -45,3 +45,5 @@ test-junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/maps-compose-utils/build.gradle
+++ b/maps-compose-utils/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'kotlin-android'
+    alias libs.plugins.compose.compiler
 }
 
 android {
@@ -18,10 +19,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
-    }
-
     buildFeatures {
         buildConfig false
         compose true
@@ -30,7 +27,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += '-Xexplicit-api=strict'
-        freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+        freeCompilerArgs += '-opt-in=kotlin.RequiresOptIn'
     }
 }
 

--- a/maps-compose-widgets/build.gradle
+++ b/maps-compose-widgets/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'kotlin-android'
+    alias libs.plugins.compose.compiler
 }
 
 android {
@@ -18,10 +19,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
-    }
-
     buildFeatures {
         buildConfig false
         compose true
@@ -30,7 +27,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += '-Xexplicit-api=strict'
-        freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+        freeCompilerArgs += '-opt-in=kotlin.RequiresOptIn'
     }
 }
 

--- a/maps-compose/build.gradle
+++ b/maps-compose/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'kotlin-android'
+    alias libs.plugins.compose.compiler
 }
 
 android {
@@ -18,10 +19,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composecompiler.get()
-    }
-
     buildFeatures {
         buildConfig false
         compose true
@@ -30,7 +27,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += '-Xexplicit-api=strict'
-        freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+        freeCompilerArgs += '-opt-in=kotlin.RequiresOptIn'
 
         freeCompilerArgs += [
                 "-P",
@@ -42,14 +39,14 @@ android {
             freeCompilerArgs += [
                     "-P",
                     "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                            project.buildDir.absolutePath + "/compose_compiler"
+                            project.layout.buildDirectory.absolutePath + "/compose_compiler"
             ]
         }
         if (findProperty("composeCompilerMetrics") == "true") {
             freeCompilerArgs += [
                     "-P",
                     "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                            project.buildDir.absolutePath + "/compose_compiler"
+                            project.layout.buildDirectory.absolutePath + "/compose_compiler"
             ]
         }
     }


### PR DESCRIPTION
Kotlin 2.0.0 has been updated, and there are a few collateral changes. The K2 compiler is now activated by default.

- The Jetpack Compose compiler has moved to the Kotlin repository. This PR migrates to use the new plugin, as per [the migration instructions](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html).
- `freeCompilerArgs` semantics migrated.
- buildconfig removed from gradle.properties, since this is scheduled to be removed in AGP 9.0.0.
- Some minor libraries updated.
- Kotlin version increased to 2.0.0