### PR TITLE
chore: updating JaCoCo comment

### DIFF
--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   run-instrumentation-test:
     runs-on: macOS-latest-large # enables hardware acceleration in the virtual machine
+    permissions:
+      pull-requests: write
     timeout-minutes: 30
     steps:
     - name: Checkout Repo

--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -70,6 +70,7 @@ jobs:
         min-coverage-changed-files: 60
         title: Code Coverage
         debug-mode: false
+        update-comment: true
 
     - name: Get the Coverage info
       run: |


### PR DESCRIPTION
This PR updates the test coverage comment from JaCoCo, so it doesn't repeat after new commits are added to the PR.