### PR TITLE
chore: using Java 1.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4.2.1
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
 
     # Run dokka and create tar

--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4.2.1
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
 
     - name: Inject Maps API Key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4.2.1
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
     - name: Create .gpg key
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4.2.1
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Build modules

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
@@ -39,7 +39,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ junit = "4.13.2"
 kotlin = "2.0.0"
 kotlinxCoroutines = "1.8.1"
 material = "1.12.0"
-mapsktx = "5.1.0"
+mapsktx = "5.1.1"
 mapsecrets = "2.0.1"
 org-jacoco-core = "0.8.11"
 

--- a/maps-compose-utils/build.gradle.kts
+++ b/maps-compose-utils/build.gradle.kts
@@ -13,8 +13,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
@@ -23,7 +23,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
         freeCompilerArgs += "-Xexplicit-api=strict"
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }

--- a/maps-compose-widgets/build.gradle.kts
+++ b/maps-compose-widgets/build.gradle.kts
@@ -13,8 +13,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
@@ -23,7 +23,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
         freeCompilerArgs += listOf(
             "-Xexplicit-api=strict",
             "-Xopt-in=kotlin.RequiresOptIn"

--- a/maps-compose/build.gradle.kts
+++ b/maps-compose/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
@@ -24,7 +24,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
         val stabilityConfigurationFile = layout.projectDirectory.file("compose_compiler_stability_config.conf").asFile
         freeCompilerArgs += listOf(
             "-Xexplicit-api=strict",


### PR DESCRIPTION
This PR (depending on https://github.com/googlemaps/android-maps-ktx/pull/267) brings back Java 1.8 compatibility.