### PR TITLE
chore: specifying right version in Java version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
     - uses: gradle/actions/wrapper-validation@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4.2.1
       with:
         java-version: '21'


### PR DESCRIPTION
This PR updates a comment where the wrong Java version was being specified (17 when we are using 21)