### PR TITLE
fix: update circle to be black and have a radius of 10

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/Circle.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Circle.kt
@@ -54,8 +54,8 @@ internal class CircleNode(
 public fun Circle(
     center: LatLng,
     clickable: Boolean = false,
-    fillColor: Color = Color.Transparent,
-    radius: Double = 0.0,
+    fillColor: Color = Color.Black,
+    radius: Double = 10.0,
     strokeColor: Color = Color.Black,
     strokePattern: List<PatternItem>? = null,
     strokeWidth: Float = 10f,


### PR DESCRIPTION
Fixes #531 

Update the `Circle` function to use `Color.Black` as default, and a radius of `10`
