### PR TITLE
fix: potential fix for publication issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       uses: gradle/actions/wrapper-validation@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: '21'
         distribution: 'adopt'

--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: gradle/actions/wrapper-validation@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: '21'
         distribution: 'adopt'

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.6.0
+        uses: actions/setup-java@v4.2.1
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
     - uses: gradle/actions/wrapper-validation@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: '21'
         distribution: 'adopt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: gradle/actions/wrapper-validation@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.2.1
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
We realised that 6.4.2.and 6.4.3 were not published on Maven, despite the logs looking good. The only change in the configuration that could have potentially caused this is this update, since all the other changes were not related to the configuration files.