### PR TITLE
docs: Fix broken link to maps-app project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dependencies {
 
 ## Sample App
 
-Currently, there are two sample apps in the repository: [maps-app](app) and [navigation-app](navigation-app). Each of them run a different version of the Android Maps Compose SDK, where either the maps or the navigation SDK are run, respectively.
+Currently, there are two sample apps in the repository: [maps-app](maps-app) and [navigation-app](navigation-app). Each of them run a different version of the Android Maps Compose SDK, where either the maps or the navigation SDK are run, respectively.
 
 To run the maps demo app, ensure you've met the requirements above then:
 


### PR DESCRIPTION
I skipped the "create an issue" step due to this being a very trivial documentation fix – do let me know if you'd still need one though. 🙂 