### PR TITLE
fix: fix crash on Lazy List

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.content.res.Configuration
 import android.location.Location
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues


### PR DESCRIPTION
The following PR fixes an issue introduced in https://github.com/googlemaps/android-maps-compose/pull/670. The crash happened because the `delegate` was being assigned inside factory, but it was not retained across recompositions. When `onRelease` or update tried to access delegate!!, it was sometimes null, causing a crash.

Fixes #687  🦕
