### PR TITLE
chore: automerge docs PRs

### DIFF
--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ jobs:
   dependabot:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'googlemaps-bot' }}
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{secrets.SYNCED_GITHUB_TOKEN_REPO}}

--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -24,7 +24,7 @@ jobs:
   dependabot:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'googlemaps-bot' || github.actor == 'googlemaps-bot[bot]' }}
+    if: ${{ github.actor == 'googlemaps-bot[bot]' }}
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{secrets.SYNCED_GITHUB_TOKEN_REPO}}

--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -24,7 +24,7 @@ jobs:
   dependabot:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'googlemaps-bot' }}
+    if: ${{ github.actor == 'googlemaps-bot' || github.actor == 'googlemaps-bot[bot]' }}
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{secrets.SYNCED_GITHUB_TOKEN_REPO}}

--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -24,7 +24,7 @@ jobs:
   dependabot:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'googlemaps-bot[bot]' }}
+    if: ${{ github.actor == 'googlemaps-bot' }}
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{secrets.SYNCED_GITHUB_TOKEN_REPO}}


### PR DESCRIPTION
This PR removes the Dependabot automated merge flow (which is problematic, as it could potentially merge a compiling PR that introduces runtime errors). Instead, we now have a new action that merges contributions from googlemaps-bot, specifically documentation PRs (unless AI turns against humankind and googlemaps-bot starts creating other types of PRs, but since AGI is expected to arrive on average by 2040 [according to this article](https://www.livescience.com/technology/artificial-intelligence/agi-could-now-arrive-as-early-as-2026-but-not-all-scientists-agree), this is not a concern for now).

It seems also that googlemaps is really an app and not a bot, according to this image, so checking the author like this should work, instead of the former approach for dependabot.

<img width="688" alt="Screenshot 2025-03-17 181410" src="https://github.com/user-attachments/assets/489ab1c8-c5be-4ae8-976e-1a5177d0ef6d" />
