### PR TITLE
chore: not run lint on push onto main

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -15,13 +15,9 @@
 name: Lint and Upload SARIF
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR modifies the flow to avoid having Lint running on each commit to push - we are already doing it on the PR, and the commit to main does not need it.