### PR TITLE
fix: fixed issue on MarkerComposable

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
@@ -1,7 +1,5 @@
 package com.google.maps.android.compose
 
-import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
@@ -15,6 +13,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.graphics.applyCanvas
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import androidx.core.graphics.createBitmap
 
 @Composable
 internal fun rememberComposeBitmapDescriptor(
@@ -37,7 +36,6 @@ private fun renderComposableToBitmapDescriptor(
     compositionContext: CompositionContext,
     content: @Composable () -> Unit,
 ): BitmapDescriptor {
-    val fakeCanvas = Canvas()
     val composeView =
         ComposeView(parent.context)
             .apply {
@@ -50,8 +48,6 @@ private fun renderComposableToBitmapDescriptor(
             }
             .also(parent::addView)
 
-    composeView.draw(fakeCanvas)
-
     composeView.measure(measureSpec, measureSpec)
 
     if (composeView.measuredWidth == 0 || composeView.measuredHeight == 0) {
@@ -62,12 +58,7 @@ private fun renderComposableToBitmapDescriptor(
     composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)
 
     val bitmap =
-        Bitmap
-            .createBitmap(
-                composeView.measuredWidth,
-                composeView.measuredHeight,
-                Bitmap.Config.ARGB_8888,
-            )
+        createBitmap(composeView.measuredWidth, composeView.measuredHeight)
 
     bitmap.applyCanvas { composeView.draw(this) }
 


### PR DESCRIPTION
This PR fixes an issue that was not properly done on the MarkerComposable, and that was probably introducing some performance issues (not all the problems we had were attributable to it, but certainly a percentage of them).

The main issue is that we have been measuring the view after drawing it. The procedure should have been [measure and layout, then draw](https://developer.android.com/guide/topics/ui/how-android-draws).

The `fakeCanvas` was also unnecessary, since `applyCanvas` creates one.

So overall, this should improve performance a bit.