### PR TITLE
chore: modified path for the Test report

### DIFF
--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -84,4 +84,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-reports
-        path: ./app/build/reports
+        path: ./maps-app/build/reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
       if: always()
       with:
         name: my-artifact
-        path: app/build/reports
+        path: maps-app/build/reports


### PR DESCRIPTION
This PR fixes the path for the Lint and Screenshot report, which was pointing out to the previous folder structure (`app` instead of `maps-app`)