### PR TITLE
chore: remove rememberMarkerState from samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Circle(
 Markers and other elements need to be recomposed in the screen. To achieve recomposition, you can set mutable properties of state objects:
 
 ```kotlin
-val markerState = rememberMarkerState(position = singapore)
+val markerState = rememberUpdatedMarkerState(position = singapore)
 
 //...
 

--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -218,7 +218,7 @@ class GoogleMapViewTests {
     @Test(expected = IllegalStateException::class)
     fun testMarkerStateCannotBeReused() {
         initMap {
-            val markerState = rememberMarkerState()
+            val markerState = rememberUpdatedMarkerState()
             Marker(
                 state = markerState
             )
@@ -231,7 +231,7 @@ class GoogleMapViewTests {
     @Test(expected = IllegalStateException::class)
     fun testMarkerStateInsideMarkerComposableCannotBeReused() {
         initMap {
-            val markerState = rememberMarkerState()
+            val markerState = rememberUpdatedMarkerState()
             MarkerComposable(
                 keys = arrayOf("marker1"),
                 state = markerState,
@@ -254,7 +254,7 @@ class GoogleMapViewTests {
     @Test(expected = IllegalStateException::class)
     fun testMarkerStateInsideMarkerInfoWindowComposableCannotBeReused() {
         initMap {
-            val markerState = rememberMarkerState()
+            val markerState = rememberUpdatedMarkerState()
             MarkerInfoWindowComposable(
                 keys = arrayOf("marker1"),
                 state = markerState,

--- a/maps-app/src/main/java/com/google/maps/android/compose/AccessibilityActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/AccessibilityActivity.kt
@@ -37,7 +37,7 @@ class AccessibilityActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            val singaporeState = rememberMarkerState(position = singapore)
+            val singaporeState = rememberUpdatedMarkerState(position = singapore)
             val cameraPositionState = rememberCameraPositionState {
                 position = defaultCameraPosition
             }

--- a/maps-app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
@@ -142,11 +142,11 @@ fun GoogleMapView(
     mapColorScheme: ComposeMapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM,
     content: @Composable () -> Unit = {}
 ) {
-    val singaporeState = rememberMarkerState(position = singapore)
-    val singapore2State = rememberMarkerState(position = singapore2)
-    val singapore3State = rememberMarkerState(position = singapore3)
-    val singapore4State = rememberMarkerState(position = singapore4)
-    val singapore5State = rememberMarkerState(position = singapore5)
+    val singaporeState = rememberUpdatedMarkerState(position = singapore)
+    val singapore2State = rememberUpdatedMarkerState(position = singapore2)
+    val singapore3State = rememberUpdatedMarkerState(position = singapore3)
+    val singapore4State = rememberUpdatedMarkerState(position = singapore4)
+    val singapore5State = rememberUpdatedMarkerState(position = singapore5)
 
     var circleCenter by remember { mutableStateOf(singapore) }
     if (!singaporeState.isDragging) {

--- a/maps-app/src/main/java/com/google/maps/android/compose/MapInColumnActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/MapInColumnActivity.kt
@@ -185,7 +185,7 @@ private fun GoogleMapViewInColumn(
     cameraPositionState: CameraPositionState,
     onMapLoaded: () -> Unit,
 ) {
-    val singaporeState = rememberMarkerState(position = singapore)
+    val singaporeState = rememberUpdatedMarkerState(position = singapore)
 
     var uiSettings by remember { mutableStateOf(MapUiSettings(compassEnabled = false)) }
     var mapProperties by remember {

--- a/maps-app/src/main/java/com/google/maps/android/compose/RecompositionActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/RecompositionActivity.kt
@@ -70,7 +70,7 @@ class RecompositionActivity : ComponentActivity() {
         cameraPositionState: CameraPositionState = rememberCameraPositionState(),
         content: @Composable () -> Unit = {},
     ) {
-        val markerState = rememberMarkerState(position = singapore)
+        val markerState = rememberUpdatedMarkerState(position = singapore)
 
         val uiSettings by remember { mutableStateOf(MapUiSettings(compassEnabled = false)) }
         val mapProperties by remember {

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/AdvancedMarkersActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/AdvancedMarkersActivity.kt
@@ -44,7 +44,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.rememberCameraPositionState
-import com.google.maps.android.compose.rememberMarkerState
+import com.google.maps.android.compose.rememberUpdatedMarkerState
 
 
 private const val TAG = "AdvancedMarkersActivity"
@@ -70,10 +70,10 @@ class AdvancedMarkersActivity : ComponentActivity(), OnMapsSdkInitializedCallbac
             val mapProperties by remember {
                 mutableStateOf(MapProperties(mapType = MapType.NORMAL))
             }
-            val marker1State = rememberMarkerState(position = santiago)
-            val marker2State = rememberMarkerState(position = bogota)
-            val marker3State = rememberMarkerState(position = lima)
-            val marker4State = rememberMarkerState(position = salvador)
+            val marker1State = rememberUpdatedMarkerState(position = santiago)
+            val marker2State = rememberUpdatedMarkerState(position = bogota)
+            val marker3State = rememberUpdatedMarkerState(position = lima)
+            val marker4State = rememberUpdatedMarkerState(position = salvador)
 
             // Drawing on the map is accomplished with a child-based API
             val markerClick: (Marker) -> Boolean = {

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
@@ -50,7 +50,7 @@ import com.google.maps.android.compose.clustering.Clustering
 import com.google.maps.android.compose.clustering.rememberClusterManager
 import com.google.maps.android.compose.clustering.rememberClusterRenderer
 import com.google.maps.android.compose.rememberCameraPositionState
-import com.google.maps.android.compose.rememberMarkerState
+import com.google.maps.android.compose.rememberUpdatedMarkerState
 import com.google.maps.android.compose.singapore
 import com.google.maps.android.compose.singapore2
 import kotlin.random.Random
@@ -119,7 +119,7 @@ fun GoogleMapClustering(items: List<MyItem>) {
         }
 
         MarkerInfoWindow(
-            state = rememberMarkerState(position = singapore),
+            state = rememberUpdatedMarkerState(position = singapore),
             onClick = {
                 Log.d(TAG, "Non-cluster marker clicked! $it")
                 true

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/markerdragevents/MarkerDragEventsActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/markerdragevents/MarkerDragEventsActivity.kt
@@ -30,7 +30,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.defaultCameraPosition
 import com.google.maps.android.compose.rememberCameraPositionState
-import com.google.maps.android.compose.rememberMarkerState
+import com.google.maps.android.compose.rememberUpdatedMarkerState
 import com.google.maps.android.compose.singapore
 import com.google.maps.android.compose.theme.MapsComposeSampleTheme
 import kotlinx.coroutines.flow.dropWhile
@@ -87,7 +87,7 @@ private fun DraggableMarker(
     onDrag: (LatLng) -> Unit = {},
     onDragEnd: () -> Unit = {}
 ) {
-    val markerState = rememberMarkerState(position = singapore)
+    val markerState = rememberUpdatedMarkerState(position = singapore)
 
     Marker(
         state = markerState,

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/syncingdraggablemarkerwithdatamodel/SyncingDraggableMarkerWithDataModelActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/syncingdraggablemarkerwithdatamodel/SyncingDraggableMarkerWithDataModelActivity.kt
@@ -148,7 +148,7 @@ private fun LocationMarker(
     // It is the price we pay for having source of truth baked into
     // com.google.android.gms.maps.model.Marker, and consequently MarkerState.
     //
-    // Do not use rememberMarkerState() here, because it uses rememberSaveable();
+    // Do not use rememberUpdatedMarkerState() here, because it uses rememberSaveable();
     // we want to save the position to persistent storage as part of our data model
     // instead - rememberSaveable() would add a conflicting source of truth.
     val markerState = remember { MarkerState(locationData.position) }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -200,7 +200,7 @@ public class MarkerState private constructor(position: LatLng) {
         """
     )
 )
-public fun rememberMarkerState(
+public fun rememberUpdatedMarkerState(
     key: String? = null,
     position: LatLng = LatLng(0.0, 0.0)
 ): MarkerState = rememberSaveable(key = key, saver = MarkerState.Saver) {
@@ -245,7 +245,7 @@ public fun rememberUpdatedMarkerState(
 @Composable
 @GoogleMapComposable
 public fun Marker(
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     contentDescription: String? = "",
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
@@ -320,7 +320,7 @@ public fun Marker(
 @GoogleMapComposable
 public fun MarkerComposable(
     vararg keys: Any,
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     contentDescription: String? = "",
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
@@ -392,7 +392,7 @@ public fun MarkerComposable(
 @Composable
 @GoogleMapComposable
 public fun MarkerInfoWindow(
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
     draggable: Boolean = false,
@@ -465,7 +465,7 @@ public fun MarkerInfoWindow(
 @GoogleMapComposable
 public fun MarkerInfoWindowComposable(
     vararg keys: Any,
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
     draggable: Boolean = false,
@@ -537,7 +537,7 @@ public fun MarkerInfoWindowComposable(
 @Composable
 @GoogleMapComposable
 public fun MarkerInfoWindowContent(
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
     draggable: Boolean = false,
@@ -609,7 +609,7 @@ public fun MarkerInfoWindowContent(
 @Composable
 @GoogleMapComposable
 private fun MarkerImpl(
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     contentDescription: String? = "",
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
@@ -726,7 +726,7 @@ private fun MarkerImpl(
 @Composable
 @GoogleMapComposable
 public fun AdvancedMarker(
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     contentDescription: String? = "",
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),
@@ -804,7 +804,7 @@ public fun AdvancedMarker(
 @Composable
 @GoogleMapComposable
 private fun AdvancedMarkerImpl(
-    state: MarkerState = rememberMarkerState(),
+    state: MarkerState = rememberUpdatedMarkerState(),
     contentDescription: String? = "",
     alpha: Float = 1.0f,
     anchor: Offset = Offset(0.5f, 1.0f),


### PR DESCRIPTION
`rememberMarkerState` has been deprecated in the commit https://github.com/googlemaps/android-maps-compose/commit/0d6f023767f8ef8ede5950ecbb66f3b0c1f0e8a2.

We should replace `rememberMarkerState` with `rememberUpdatedMarkerState`, so users can see the best practices in the samples.