### PR TITLE
chore: libraries updated

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,35 +1,24 @@
 [versions]
-accompanistPermissions = "0.37.0"
 activitycompose = "1.10.1"
-agp = "8.9.1"
+agp = "8.9.3"
 androidCore = "1.6.1"
 androidx-core = "1.16.0"
 androidxtest = "1.6.2"
 compose-bom = "2025.04.00"
-dokka = "1.9.20"
+dokka = "2.0.0"
 espresso = "3.6.1"
 jacoco-plugin = "0.2.1"
 junit = "4.13.2"
-junitVersion = "1.2.1"
 junitktx = "1.2.1"
-kotlin = "2.1.10"
-kotlinxCoroutines = "1.10.1"
+kotlin = "2.2.0"
+kotlinxCoroutines = "1.10.2"
 leakcanaryAndroid = "2.12"
-lifecycleRuntimeKtx = "2.8.7"
 mapsecrets = "2.0.1"
 mapsktx = "5.2.0"
-navigation = "6.2.0"
 org-jacoco-core = "0.8.12"
-places = "4.2.0"
-playServicesLocation = "21.3.0"
-robolectric = "4.14.1"
-screenshot = "0.0.1-alpha08"
-secretsGradlePlugin = "2.0.1"
-truth = "1.4.4"
+screenshot = "0.0.1-alpha10"
 
 [libraries]
-# robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activitycompose" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
@@ -39,19 +28,12 @@ androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidCore" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitktx" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidCore" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxtest" }
-androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 jacoco-android-plugin = { module = "com.mxalbert.gradle:jacoco-android", version.ref = "jacoco-plugin", version.require = "0.2.1" }
 kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
@@ -62,12 +44,8 @@ leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", ve
 maps-ktx-std = { module = "com.google.maps.android:maps-ktx", version.ref = "mapsktx" }
 maps-ktx-utils = { module = "com.google.maps.android:maps-utils-ktx", version.ref = "mapsktx" }
 maps-secrets-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "mapsecrets" }
-navigation = { module = "com.google.android.libraries.navigation:navigation", version.ref = "navigation" }
 org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
-places = { group = "com.google.android.libraries.places", name = "places", version.ref = "places" }
-play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 test-junit = { module = "junit:junit", version.ref = "junit" }
-truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -75,4 +53,3 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot"}
-secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activitycompose = "1.10.1"
-agp = "8.9.3"
+agp = "8.10.1"
 androidCore = "1.6.1"
 androidx-core = "1.16.0"
 androidxtest = "1.6.2"


### PR DESCRIPTION
This PR updates some of the dependencies, most notably [Kotlin to 2.2.0 ](https://github.com/JetBrains/kotlin/releases/tag/v2.2.0)There does not seem to be any required change in the code.

Dokka has been updated to 2.0.0. We do not require a migration in our Convention plugin, and `./gradlew dokkaHtmlMultiModule` works to deploy the documentation.

There is a non-resolved bug with Compose that breaks the Scale Bar, so the Compose BoM is not updated.

This PR will not trigger a release, to pack it with some other features.