### PR TITLE
chore: ditch snapshot

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -88,11 +88,7 @@ class PublishingConventionPlugin : Plugin<Project> {
             }
             repositories {
                 maven {
-                    val releasesRepoUrl =
-                        uri("https://central.sonatype.com/repository/maven-snapshots/")
-                    val snapshotsRepoUrl =
-                        uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-                    url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+                    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                     credentials {
                         username = project.findProperty("sonatypeToken") as String?
                         password = project.findProperty("sonatypeTokenPassword") as String?


### PR DESCRIPTION
We are receiving a 401 when publishing, since the URL is targeting a snapshot. But we are not targeting Snapshots. This PR ditches the snapshot and uses instead the Maven Central URL.