### PR TITLE
fix: always run the `launchSubcomposition` on the main thread

### DIFF
--- a/.github/workflows/instrumentation-test.yml
+++ b/.github/workflows/instrumentation-test.yml
@@ -18,8 +18,6 @@ name: Run instrumentation tests
 on:
   repository_dispatch:
     types: [test]
-  push:
-    branches-ignore: ['gh-pages']
   pull_request:
     branches-ignore: ['gh-pages']
   workflow_dispatch:

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -35,11 +35,26 @@ jobs:
       - name: Run Android Lint
         run: ./gradlew lint
 
-      - name: Merge SARIF files
-        run: |
-          jq -s '{ "$schema": "https://json.schemastore.org/sarif-2.1.0", "version": "2.1.0", "runs": map(.runs) | add }'  maps-compose/build/reports/lint-results.sarif  maps-compose-utils/build/reports/lint-results.sarif  maps-compose-widgets/build/reports/lint-results.sarif  maps-app/build/reports/lint-results.sarif > merged.sarif
-
-      - name: Upload SARIF file
+      - name: Upload SARIF from maps-compose
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: merged.sarif
+          sarif_file: maps-compose/build/reports/lint-results.sarif
+          category: maps-compose
+
+      - name: Upload SARIF from maps-compose-utils
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: maps-compose-utils/build/reports/lint-results.sarif
+          category: maps-compose-utils
+
+      - name: Upload SARIF from maps-compose-widgets
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: maps-compose-widgets/build/reports/lint-results.sarif
+          category: maps-compose-widgets
+
+      - name: Upload SARIF from maps-app
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: maps-app/build/reports/lint-results.sarif
+          category: maps-app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ name: Run unit tests
 on:
   repository_dispatch:
     types: [test]
-  push:
-    branches-ignore: ['gh-pages']
   pull_request:
     branches-ignore: ['gh-pages']
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ You no longer need to specify the Maps SDK for Android or its Utility Library as
 
 ```groovy
 dependencies {
-    implementation 'com.google.maps.android:maps-compose:6.7.1'
+    implementation 'com.google.maps.android:maps-compose:6.7.2'
 
     // Optionally, you can include the Compose utils library for Clustering,
     // Street View metadata checks, etc.
-    implementation 'com.google.maps.android:maps-compose-utils:6.7.1'
+    implementation 'com.google.maps.android:maps-compose-utils:6.7.2'
 
     // Optionally, you can include the widgets library for ScaleBar, etc.
-    implementation 'com.google.maps.android:maps-compose-widgets:6.7.1'
+    implementation 'com.google.maps.android:maps-compose-widgets:6.7.2'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ You no longer need to specify the Maps SDK for Android or its Utility Library as
 
 ```groovy
 dependencies {
-    implementation 'com.google.maps.android:maps-compose:6.7.0'
+    implementation 'com.google.maps.android:maps-compose:6.7.1'
 
     // Optionally, you can include the Compose utils library for Clustering,
     // Street View metadata checks, etc.
-    implementation 'com.google.maps.android:maps-compose-utils:6.7.0'
+    implementation 'com.google.maps.android:maps-compose-utils:6.7.1'
 
     // Optionally, you can include the widgets library for ScaleBar, etc.
-    implementation 'com.google.maps.android:maps-compose-widgets:6.7.0'
+    implementation 'com.google.maps.android:maps-compose-widgets:6.7.1'
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val projectArtifactId by extra { project: Project ->
 
 allprojects {
     group = "com.google.maps.android"
-    version = "6.7.0"
+    version = "6.7.1"
     val projectArtifactId by extra { project.name }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val projectArtifactId by extra { project: Project ->
 
 allprojects {
     group = "com.google.maps.android"
-    version = "6.7.1"
+    version = "6.7.2"
     val projectArtifactId by extra { project.name }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ mapsecrets = "2.0.1"
 mapsktx = "5.2.0"
 org-jacoco-core = "0.8.12"
 screenshot = "0.0.1-alpha10"
+constraintlayout = "2.2.1"
+material = "1.12.0"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -48,6 +50,8 @@ maps-ktx-utils = { module = "com.google.maps.android:maps-utils-ktx", version.re
 maps-secrets-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "mapsecrets" }
 org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
 test-junit = { module = "junit:junit", version.ref = "junit" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/maps-app/build.gradle.kts
+++ b/maps-app/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
     implementation(libs.kotlin)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.compose.ui.preview.tooling)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.material)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.leakcanary.android)
 

--- a/maps-app/src/main/AndroidManifest.xml
+++ b/maps-app/src/main/AndroidManifest.xml
@@ -73,6 +73,9 @@
         android:name=".RecompositionActivity"
         android:exported="false"/>
     <activity
+        android:name=".FragmentDemoActivity"
+        android:exported="false"/>
+    <activity
         android:name=".markerexamples.markerdragevents.MarkerDragEventsActivity"
         android:exported="false"/>
     <activity

--- a/maps-app/src/main/java/com/google/maps/android/compose/FragmentDemoActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/FragmentDemoActivity.kt
@@ -1,0 +1,23 @@
+package com.google.maps.android.compose
+
+
+import android.os.Bundle
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.widget.ViewPager2
+
+class FragmentDemoActivity : FragmentActivity() {
+
+    private lateinit var viewPager: ViewPager2
+    private lateinit var pagerAdapter: MapFragmentPagerAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_fragment_demo)
+
+        viewPager = findViewById(R.id.view_pager)
+
+        pagerAdapter = MapFragmentPagerAdapter(this)
+        viewPager.adapter = pagerAdapter
+
+    }
+}

--- a/maps-app/src/main/java/com/google/maps/android/compose/GoogleMapComposeFragment.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/GoogleMapComposeFragment.kt
@@ -1,0 +1,142 @@
+package com.google.maps.android.compose
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset // For MarkerComposable anchor
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+
+
+enum class MarkerType {
+    CUSTOM_CONTENT_MARKER,        // To use com.google.maps.android.compose.MarkerComposable with your Text
+    STANDARD_MARKER_WITH_SNIPPET  // To use the standard com.google.maps.android.compose.Marker
+}
+
+data class MapConfig(
+    val initialLatLng: LatLng,
+    val initialZoom: Float,
+    val title: String,
+    val markerType: MarkerType = MarkerType.CUSTOM_CONTENT_MARKER, // Default
+    val standardMarkerSnippet: String? = null
+)
+
+class GoogleMapComposeFragment : Fragment() {
+
+    private var mapConfig: MapConfig? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            val lat = it.getDouble(ARG_LAT, Double.NaN)
+            val lng = it.getDouble(ARG_LNG, Double.NaN)
+            val zoom = it.getFloat(ARG_ZOOM, 10f)
+            val title = it.getString(ARG_TITLE, "Map")
+
+            val markerTypeName = it.getString(ARG_MARKER_TYPE)
+            val markerType = markerTypeName?.let { name ->
+                try {
+                    MarkerType.valueOf(name)
+                } catch (e: IllegalArgumentException) {
+                    MarkerType.CUSTOM_CONTENT_MARKER
+                }
+            } ?: MarkerType.CUSTOM_CONTENT_MARKER
+
+            val snippet = it.getString(ARG_STANDARD_MARKER_SNIPPET)
+
+            if (!lat.isNaN() && !lng.isNaN()) {
+                mapConfig = MapConfig(
+                    initialLatLng = LatLng(lat, lng),
+                    initialZoom = zoom,
+                    title = title,
+                    markerType = markerType,
+                    standardMarkerSnippet = snippet
+                )
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            MaterialTheme {
+                val currentConfig = mapConfig ?: MapConfig(
+                    initialLatLng = LatLng(0.0, 0.0),
+                    initialZoom = 2f,
+                    title = "Default Map",
+                    markerType = MarkerType.CUSTOM_CONTENT_MARKER
+                )
+                MapContent(config = currentConfig)
+            }
+        }
+    }
+
+    @Composable
+    fun MapContent(config: MapConfig) {
+        val cameraPositionState = rememberCameraPositionState {
+            position = CameraPosition.fromLatLngZoom(config.initialLatLng, config.initialZoom)
+        }
+
+        GoogleMap(
+            cameraPositionState = cameraPositionState
+        ) {
+            when (config.markerType) {
+                MarkerType.CUSTOM_CONTENT_MARKER -> {
+                    val markerState = rememberUpdatedMarkerState(position = config.initialLatLng)
+                    markerState.position = config.initialLatLng
+
+                    MarkerComposable(
+                        state = markerState,
+                        anchor = Offset(0.5f, 1.0f)
+                    ){
+                        Text(text = "Hello, World! (from ${config.title})")
+                    }
+                }
+                MarkerType.STANDARD_MARKER_WITH_SNIPPET -> {
+                    val markerState = rememberUpdatedMarkerState(position = config.initialLatLng)
+                    markerState.position = config.initialLatLng
+
+                    Marker(
+                        state = markerState,
+                        title = config.title,
+                        snippet = config.standardMarkerSnippet ?: "Standard Marker Snippet" // Snippet for the info window
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val ARG_LAT = "arg_lat"
+        private const val ARG_LNG = "arg_lng"
+        private const val ARG_ZOOM = "arg_zoom"
+        private const val ARG_TITLE = "arg_title"
+        private const val ARG_MARKER_TYPE = "arg_marker_type"
+        private const val ARG_STANDARD_MARKER_SNIPPET = "arg_standard_marker_snippet"
+
+        @JvmStatic
+        fun newInstance(config: MapConfig): GoogleMapComposeFragment {
+            return GoogleMapComposeFragment().apply {
+                arguments = Bundle().apply {
+                    putDouble(ARG_LAT, config.initialLatLng.latitude)
+                    putDouble(ARG_LNG, config.initialLatLng.longitude)
+                    putFloat(ARG_ZOOM, config.initialZoom)
+                    putString(ARG_TITLE, config.title)
+                    putString(ARG_MARKER_TYPE, config.markerType.name)
+                    config.standardMarkerSnippet?.let { putString(ARG_STANDARD_MARKER_SNIPPET, it) }
+                }
+            }
+        }
+    }
+}

--- a/maps-app/src/main/java/com/google/maps/android/compose/MainActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/MainActivity.kt
@@ -16,6 +16,7 @@ package com.google.maps.android.compose
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.StrictMode
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -48,6 +49,15 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectDiskReads()
+                .penaltyLog()
+                .penaltyDeath()
+                .build()
+        )
+
         setContent {
             MapsComposeSampleTheme {
                 Surface(

--- a/maps-app/src/main/java/com/google/maps/android/compose/MainActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/MainActivity.kt
@@ -199,6 +199,13 @@ class MainActivity : ComponentActivity() {
                             }) {
                             Text(getString(R.string.draggable_markers_collection_with_polygon))
                         }
+                        Spacer(modifier = Modifier.padding(5.dp))
+                        Button(
+                            onClick = {
+                                context.startActivity(Intent(context, FragmentDemoActivity::class.java))
+                            }) {
+                            Text(getString(R.string.fragment_demo_activity))
+                        }
                     }
                 }
             }

--- a/maps-app/src/main/java/com/google/maps/android/compose/MapFragmentPagerAdapter.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/MapFragmentPagerAdapter.kt
@@ -1,0 +1,33 @@
+package com.google.maps.android.compose
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.gms.maps.model.LatLng
+
+class MapFragmentPagerAdapter(fragmentActivity: FragmentActivity) : FragmentStateAdapter(fragmentActivity) {
+
+    private val mapConfigs = listOf(
+        MapConfig( // First map - Los Angeles
+            initialLatLng = LatLng(34.0522, -118.2437),
+            initialZoom = 10f,
+            title = "Los Angeles",
+            // LA gets the custom content marker
+            markerType = MarkerType.CUSTOM_CONTENT_MARKER
+        ),
+        MapConfig( // Second map - New York City
+            initialLatLng = LatLng(40.7128, -74.0060),
+            initialZoom = 10f,
+            title = "New York City",
+            // NYC gets the standard marker
+            markerType = MarkerType.STANDARD_MARKER_WITH_SNIPPET,
+            standardMarkerSnippet = "The Big Apple!"
+        )
+    )
+
+    override fun getItemCount(): Int = mapConfigs.size
+
+    override fun createFragment(position: Int): Fragment {
+        return GoogleMapComposeFragment.newInstance(mapConfigs[position])
+    }
+}

--- a/maps-app/src/main/res/layout/activity_fragment_demo.xml
+++ b/maps-app/src/main/res/layout/activity_fragment_demo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FragmentDemoActivity">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:background="#80000000"
+        android:padding="16dp"
+        android:text="Swipe to switch between views"
+        android:textColor="@android:color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/maps-app/src/main/res/values/strings.xml
+++ b/maps-app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
   <string name="syncing_draggable_marker_with_data_model">Syncing Draggable Marker With Model</string>
   <string name="updating_non_draggable_marker_with_data_model">Updating Non-Draggable Marker With Model</string>
   <string name="draggable_markers_collection_with_polygon">Polygon around draggable markers</string>
+  <string name="fragment_demo_activity">Fragment Demo Activity</string>
   <string name="recomposition_activity">Recomposition Map</string>
   <string name="street_view">Street View</string>
   <string name="custom_location_button">Custom Location Button</string>

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * A compose container for a [MapView].

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -53,6 +53,7 @@ import com.google.maps.android.compose.meta.AttributionId
 import com.google.maps.android.ktx.awaitMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
@@ -218,7 +219,10 @@ private fun CoroutineScope.launchSubcomposition(
     content: @Composable @GoogleMapComposable () -> Unit,
 ): Job {
     // Use [CoroutineStart.UNDISPATCHED] to kick off GoogleMap loading immediately
-    return launch(start = CoroutineStart.UNDISPATCHED) {
+    return launch(
+        context = Dispatchers.Main,
+        start = CoroutineStart.UNDISPATCHED
+    ) {
         val map = mapView.awaitMap()
         val composition = Composition(
             applier = MapApplier(map, mapView, mapClickListeners),

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -219,10 +219,7 @@ private fun CoroutineScope.launchSubcomposition(
     content: @Composable @GoogleMapComposable () -> Unit,
 ): Job {
     // Use [CoroutineStart.UNDISPATCHED] to kick off GoogleMap loading immediately
-    return launch(
-        context = Dispatchers.Main,
-        start = CoroutineStart.UNDISPATCHED
-    ) {
+    return launch(start = CoroutineStart.UNDISPATCHED) {
         val map = mapView.awaitMap()
         val composition = Composition(
             applier = MapApplier(map, mapView, mapClickListeners),
@@ -242,7 +239,9 @@ private fun CoroutineScope.launchSubcomposition(
             }
             awaitCancellation()
         } finally {
-            composition.dispose()
+            withContext(context = Dispatchers.Main) {
+                composition.dispose()
+            }
         }
     }
 }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +36,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
@@ -44,11 +46,11 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.LocationSource
 import com.google.android.gms.maps.MapView
-import com.google.android.gms.maps.MapsApiSettings
 
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MapColorScheme
 import com.google.android.gms.maps.model.PointOfInterest
+import com.google.maps.android.compose.internal.MapsApiAttribution
 import com.google.maps.android.compose.meta.AttributionId
 import com.google.maps.android.ktx.awaitMap
 import kotlinx.coroutines.CoroutineScope
@@ -110,101 +112,116 @@ public fun GoogleMap(
         return
     }
 
-    // rememberUpdatedState and friends are used here to make these values observable to
-    // the subcomposition without providing a new content function each recomposition
-    val mapClickListeners = remember { MapClickListeners() }.also {
-        it.indoorStateChangeListener = indoorStateChangeListener
-        it.onMapClick = onMapClick
-        it.onMapLongClick = onMapLongClick
-        it.onMapLoaded = onMapLoaded
-        it.onMyLocationButtonClick = onMyLocationButtonClick
-        it.onMyLocationClick = onMyLocationClick
-        it.onPOIClick = onPOIClick
+    val isInitialized by MapsApiAttribution.isInitialized
+
+    if (!isInitialized) {
+        val context = LocalContext.current
+        LaunchedEffect(Unit) {
+            MapsApiAttribution.addAttributionId(context)
+        }
     }
 
-    val mapUpdaterState = remember {
-        MapUpdaterState(
-            mergeDescendants,
-            contentDescription,
-            cameraPositionState,
-            contentPadding,
-            locationSource,
-            properties,
-            uiSettings,
-            mapColorScheme?.value,
-        )
-    }.also {
-        it.mergeDescendants = mergeDescendants
-        it.contentDescription = contentDescription
-        it.cameraPositionState = cameraPositionState
-        it.contentPadding = contentPadding
-        it.locationSource = locationSource
-        it.mapProperties = properties
-        it.mapUiSettings = uiSettings
-        it.mapColorScheme = mapColorScheme?.value
-    }
+    if (isInitialized) {
+        // rememberUpdatedState and friends are used here to make these values observable to
+        // the subcomposition without providing a new content function each recomposition
+        val mapClickListeners = remember { MapClickListeners() }.also {
+            it.indoorStateChangeListener = indoorStateChangeListener
+            it.onMapClick = onMapClick
+            it.onMapLongClick = onMapLongClick
+            it.onMapLoaded = onMapLoaded
+            it.onMyLocationButtonClick = onMyLocationButtonClick
+            it.onMyLocationClick = onMyLocationClick
+            it.onPOIClick = onPOIClick
+        }
 
-    val parentComposition = rememberCompositionContext()
-    val currentContent by rememberUpdatedState(content)
-    var subcompositionJob by remember { mutableStateOf<Job?>(null) }
-    val parentCompositionScope = rememberCoroutineScope()
+        val mapUpdaterState = remember {
+            MapUpdaterState(
+                mergeDescendants,
+                contentDescription,
+                cameraPositionState,
+                contentPadding,
+                locationSource,
+                properties,
+                uiSettings,
+                mapColorScheme?.value,
+            )
+        }.also {
+            it.mergeDescendants = mergeDescendants
+            it.contentDescription = contentDescription
+            it.cameraPositionState = cameraPositionState
+            it.contentPadding = contentPadding
+            it.locationSource = locationSource
+            it.mapProperties = properties
+            it.mapUiSettings = uiSettings
+            it.mapColorScheme = mapColorScheme?.value
+        }
 
-    AndroidView(
-        modifier = modifier,
-        factory = { context ->
-            MapView(context, googleMapOptionsFactory()) .also { mapView ->
-                MapsApiSettings.addInternalUsageAttributionId(context, AttributionId.VALUE )
-                val componentCallbacks = object : ComponentCallbacks2 {
-                    override fun onConfigurationChanged(newConfig: Configuration) {}
-                    @Deprecated("Deprecated in Java", ReplaceWith("onTrimMemory(level)"))
-                    override fun onLowMemory() { mapView.onLowMemory() }
-                    override fun onTrimMemory(level: Int) { mapView.onLowMemory() }
-                }
-                context.registerComponentCallbacks(componentCallbacks)
+        val parentComposition = rememberCompositionContext()
+        val currentContent by rememberUpdatedState(content)
+        var subcompositionJob by remember { mutableStateOf<Job?>(null) }
+        val parentCompositionScope = rememberCoroutineScope()
 
-                val lifecycleObserver = MapLifecycleEventObserver(mapView)
+        AndroidView(
+            modifier = modifier,
+            factory = { context ->
+                MapView(context, googleMapOptionsFactory()).also { mapView ->
+                    val componentCallbacks = object : ComponentCallbacks2 {
+                        override fun onConfigurationChanged(newConfig: Configuration) {}
 
-                mapView.tag = MapTagData(componentCallbacks, lifecycleObserver)
+                        @Deprecated("Deprecated in Java", ReplaceWith("onTrimMemory(level)"))
+                        override fun onLowMemory() {
+                            mapView.onLowMemory()
+                        }
 
-                // Only register for [lifecycleOwner]'s lifecycle events while MapView is attached
-                val onAttachStateListener = object : View.OnAttachStateChangeListener {
-                    private var lifecycle: Lifecycle? = null
+                        override fun onTrimMemory(level: Int) {
+                            mapView.onLowMemory()
+                        }
+                    }
+                    context.registerComponentCallbacks(componentCallbacks)
 
-                    override fun onViewAttachedToWindow(mapView: View) {
-                        lifecycle = mapView.findViewTreeLifecycleOwner()!!.lifecycle.also {
-                            it.addObserver(lifecycleObserver)
+                    val lifecycleObserver = MapLifecycleEventObserver(mapView)
+
+                    mapView.tag = MapTagData(componentCallbacks, lifecycleObserver)
+
+                    // Only register for [lifecycleOwner]'s lifecycle events while MapView is attached
+                    val onAttachStateListener = object : View.OnAttachStateChangeListener {
+                        private var lifecycle: Lifecycle? = null
+
+                        override fun onViewAttachedToWindow(mapView: View) {
+                            lifecycle = mapView.findViewTreeLifecycleOwner()!!.lifecycle.also {
+                                it.addObserver(lifecycleObserver)
+                            }
+                        }
+
+                        override fun onViewDetachedFromWindow(v: View) {
+                            lifecycle?.removeObserver(lifecycleObserver)
+                            lifecycle = null
+                            lifecycleObserver.moveToBaseState()
                         }
                     }
 
-                    override fun onViewDetachedFromWindow(v: View) {
-                        lifecycle?.removeObserver(lifecycleObserver)
-                        lifecycle = null
-                        lifecycleObserver.moveToBaseState()
-                    }
+                    mapView.addOnAttachStateChangeListener(onAttachStateListener)
                 }
-
-                mapView.addOnAttachStateChangeListener(onAttachStateListener)
-            }
-        },
-        onReset = { /* View is detached. */ },
-        onRelease = { mapView ->
-            val (componentCallbacks, lifecycleObserver) = mapView.tagData
-            mapView.context.unregisterComponentCallbacks(componentCallbacks)
-            lifecycleObserver.moveToDestroyedState()
-            mapView.tag = null
-        },
-        update = { mapView ->
-            if (subcompositionJob == null) {
-                subcompositionJob = parentCompositionScope.launchSubcomposition(
-                    mapUpdaterState,
-                    parentComposition,
-                    mapView,
-                    mapClickListeners,
-                    currentContent,
-                )
-            }
-        }
-    )
+            },
+            onReset = { /* View is detached. */ },
+            onRelease = { mapView ->
+                val (componentCallbacks, lifecycleObserver) = mapView.tagData
+                mapView.context.unregisterComponentCallbacks(componentCallbacks)
+                lifecycleObserver.moveToDestroyedState()
+                mapView.tag = null
+            },
+            update = { mapView ->
+                if (subcompositionJob == null) {
+                    subcompositionJob = parentCompositionScope.launchSubcomposition(
+                        mapUpdaterState,
+                        parentComposition,
+                        mapView,
+                        mapClickListeners,
+                        currentContent,
+                    )
+                }
+            })
+    }
 }
 
 /**

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -200,7 +200,7 @@ public class MarkerState private constructor(position: LatLng) {
         """
     )
 )
-public fun rememberUpdatedMarkerState(
+public fun rememberMarkerState(
     key: String? = null,
     position: LatLng = LatLng(0.0, 0.0)
 ): MarkerState = rememberSaveable(key = key, saver = MarkerState.Saver) {

--- a/maps-compose/src/main/java/com/google/maps/android/compose/internal/MapsApiAttribution.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/internal/MapsApiAttribution.kt
@@ -1,0 +1,38 @@
+
+package com.google.maps.android.compose.internal
+
+import android.content.Context
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import com.google.android.gms.maps.MapsApiSettings
+import com.google.maps.android.compose.meta.AttributionId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Internal singleton to ensure that the Maps API attribution ID is added only once.
+ */
+internal object MapsApiAttribution {
+
+    private val hasBeenCalled = AtomicBoolean(false)
+
+    private val _isInitialized = mutableStateOf(false)
+    val isInitialized: State<Boolean> = _isInitialized
+
+    /**
+     * Adds the attribution ID to the Maps API settings. This is done on a background thread
+     * using [Dispatchers.IO]. The attribution ID is only added once.
+     *
+     * @param context The context to use to add the attribution ID.
+     */
+    fun addAttributionId(context: Context) {
+        if (hasBeenCalled.compareAndSet(false, true)) {
+            CoroutineScope(Dispatchers.IO).launch {
+                MapsApiSettings.addInternalUsageAttributionId(context, AttributionId.VALUE)
+                _isInitialized.value = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refer to #211, I found that `composition.dispose()` inside `launchSubcomposition(...)` must run on the main thread. In instrumented tests, it can be run on other threads, causing crashes because Google Maps couldn't dispose correctly.

To fix this, I've set the `launch` command within `launchSubcomposition` to always run on the main thread.

You can reproduce this issue from the https://github.com/akexorcist/maps-compose-ui-test-issue

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #211 🦕
