### PR TITLE
chore: added org to Vanniktech Maven Plugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -75,6 +75,10 @@ class PublishingConventionPlugin : Plugin<Project> {
                         name.set("Google Inc.")
                     }
                 }
+                organization {
+                    name.set("Google Inc")
+                    url.set("http://developers.google.com/maps")
+                }
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -1,6 +1,5 @@
 // buildSrc/src/main/kotlin/PublishingConventionPlugin.kt
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project


### PR DESCRIPTION
The following PR adds the org information to the vanniktech Maven plugin.