### PR TITLE
fix: bring rememberMarkerState back

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -200,7 +200,7 @@ public class MarkerState private constructor(position: LatLng) {
         """
     )
 )
-public fun rememberUpdatedMarkerState(
+public fun rememberMarkerState(
     key: String? = null,
     position: LatLng = LatLng(0.0, 0.0)
 ): MarkerState = rememberSaveable(key = key, saver = MarkerState.Saver) {


### PR DESCRIPTION
The following PR brings back rememberMarkerState, which was removed in https://github.com/googlemaps/android-maps-compose/pull/711.

The function is still deprecated.