### PR TITLE
Fix/always dispose on main thread

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * A compose container for a [MapView].

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -55,6 +55,7 @@ import com.google.maps.android.compose.meta.AttributionId
 import com.google.maps.android.ktx.awaitMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
@@ -235,7 +236,10 @@ private fun CoroutineScope.launchSubcomposition(
     content: @Composable @GoogleMapComposable () -> Unit,
 ): Job {
     // Use [CoroutineStart.UNDISPATCHED] to kick off GoogleMap loading immediately
-    return launch(start = CoroutineStart.UNDISPATCHED) {
+    return launch(
+        context = Dispatchers.Main,
+        start = CoroutineStart.UNDISPATCHED
+    ) {
         val map = mapView.awaitMap()
         val composition = Composition(
             applier = MapApplier(map, mapView, mapClickListeners),


### PR DESCRIPTION
Refer to https://github.com/googlemaps/android-maps-compose/issues/211, I found that composition.dispose() inside launchSubcomposition(...) must run on the main thread. In instrumented tests, it can be run on other threads, causing crashes because Google Maps couldn't dispose correctly.

To fix this, I've set the launch command within launchSubcomposition to always run on the main thread.

You can reproduce this issue from the https://github.com/akexorcist/maps-compose-ui-test-issue

Fixes https://github.com/googlemaps/android-maps-compose/issues/211 🦕