### PR TITLE
reproduce case issue 441951620

### DIFF
--- a/maps-app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
@@ -277,6 +277,15 @@ fun GoogleMapView(
                 fillColor = Color.Black.copy(alpha = 0.5f)
             )
 
+            MapEffect(Unit) { map ->
+                map.setOnCameraIdleListener {
+                    Log.d("MapView", "camera idle ${cameraPositionState.position}")
+                }
+                map.setOnCameraMoveListener {
+                    Log.d("MapView", "camera move ${cameraPositionState.position}")
+                }
+            }
+
             content()
         }
     }


### PR DESCRIPTION
reproduce: cameraPositionState.position always shows the same value if setOnCameraIdleListener and setOnCameraMoveListener are set

https://issuetracker.google.com/issues/441951620

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
