### PR TITLE
build: upgraded semantic release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '24'
 
       - name: Install conventionalcommits
         run: npm i -D conventional-changelog-conventionalcommits
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4.2.1
+        uses: cycjimmy/semantic-release-action@v5.0.0
         with:
           extra_plugins: |
             "@semantic-release/commit-analyzer@8.0.1"


### PR DESCRIPTION
This PR upgrades the semantic release action. This also requires an upgrade in the Node version, to 24.

Like always, this will need to be tested with a release.