### PR TITLE
chore: export all demo activities and group the activities in main screen

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlinxCoroutines = "1.10.2"
 leakcanaryAndroid = "2.14"
 mapsecrets = "2.0.1"
 mapsktx = "5.2.0"
+material3 = "1.3.2"
 org-jacoco-core = "0.8.13"
 screenshot = "0.0.1-alpha11"
 constraintlayout = "2.2.1"
@@ -29,6 +30,7 @@ androidx-compose-activity = { module = "androidx.activity:activity-compose", ver
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-preview-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }

--- a/maps-app/build.gradle.kts
+++ b/maps-app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.compose.activity)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.kotlin)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.compose.ui.preview.tooling)
@@ -70,7 +71,6 @@ dependencies {
     implementation(libs.screenshot.validation.api)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.leakcanary.android)
-
 
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.test.core)

--- a/maps-app/src/main/AndroidManifest.xml
+++ b/maps-app/src/main/AndroidManifest.xml
@@ -39,57 +39,67 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+
+    <!--
+      All activities in this sample are exported. This is for demonstration
+      purposes, to make it easy to launch each sample activity directly.
+
+      In a real-world application, you should carefully consider which activities
+      to export. In most cases, only the main launcher activity should be exported.
+      Exporting an activity means that any other app on the device can launch it.
+    -->
+    
     <activity
         android:name=".BasicMapActivity"
-        android:exported="false" />
+        android:exported="true" />
     <activity
         android:name=".markerexamples.AdvancedMarkersActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".MapInColumnActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".MapsInLazyColumnActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".markerexamples.MarkerClusteringActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".LocationTrackingActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".ScaleBarActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".StreetViewActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".CustomControlsActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".AccessibilityActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".RecompositionActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".FragmentDemoActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".markerexamples.markerdragevents.MarkerDragEventsActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".markerexamples.markerscollection.MarkersCollectionActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".markerexamples.syncingdraggablemarkerwithdatamodel.SyncingDraggableMarkerWithDataModelActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".markerexamples.updatingnodragmarkerwithdatamodel.UpdatingNoDragMarkerWithDataModelActivity"
-        android:exported="false"/>
+        android:exported="true"/>
     <activity
         android:name=".markerexamples.draggablemarkerscollectionwithpolygon.DraggableMarkersCollectionWithPolygonActivity"
-        android:exported="false"/>
+        android:exported="true"/>
 
     <!-- Used by createComponentActivity() for unit testing -->
     <activity android:name="androidx.activity.ComponentActivity" />

--- a/maps-app/src/main/java/com/google/maps/android/compose/Demo.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/Demo.kt
@@ -1,0 +1,280 @@
+
+package com.google.maps.android.compose
+
+import androidx.activity.ComponentActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.google.maps.android.compose.markerexamples.AdvancedMarkersActivity
+import com.google.maps.android.compose.markerexamples.MarkerClusteringActivity
+import com.google.maps.android.compose.markerexamples.draggablemarkerscollectionwithpolygon.DraggableMarkersCollectionWithPolygonActivity
+import com.google.maps.android.compose.markerexamples.markerdragevents.MarkerDragEventsActivity
+import com.google.maps.android.compose.markerexamples.markerscollection.MarkersCollectionActivity
+import com.google.maps.android.compose.markerexamples.syncingdraggablemarkerwithdatamodel.SyncingDraggableMarkerWithDataModelActivity
+import com.google.maps.android.compose.markerexamples.updatingnodragmarkerwithdatamodel.UpdatingNoDragMarkerWithDataModelActivity
+import kotlin.reflect.KClass
+
+// This file defines the data structures and composable functions used to display the list of
+// demo activities on the main screen of the app. The main goal is to present the demos in a
+// clear, organized, and easy-to-navigate way.
+
+/**
+ * A sealed class representing a group of related demo activities. Using a sealed class here
+ * allows us to define a closed set of categories, which is ideal for a static list of demos.
+ * This ensures that we can handle all possible categories in a type-safe way.
+ *
+ * @param title The title of the activity group.
+ * @param activities The list of activities belonging to this group.
+ */
+sealed class ActivityGroup(
+    val title: String,
+    val activities: List<Activity>
+) {
+    object MapTypes : ActivityGroup(
+        "Map Types",
+        listOf(
+            Activity(
+                "Basic Map",
+                "A simple map showing the default configuration.",
+                BasicMapActivity::class
+            ),
+            Activity(
+                "Street View",
+                "A simple Street View.",
+                StreetViewActivity::class
+            ),
+        )
+    )
+
+    object MapFeatures : ActivityGroup(
+        "Map Features",
+        listOf(
+            Activity(
+                "Location Tracking",
+                "Tracking your location on the map.",
+                LocationTrackingActivity::class
+            ),
+            Activity(
+                "Scale Bar",
+                "Displaying a scale bar on the map.",
+                ScaleBarActivity::class
+            ),
+            Activity(
+                "Custom Controls",
+                "Replacing the default location button with a custom one.",
+                CustomControlsActivity::class
+            ),
+            Activity(
+                "Accessibility",
+                "Making your map more accessible.",
+                AccessibilityActivity::class
+            ),
+        )
+    )
+
+    object Markers : ActivityGroup(
+        "Markers",
+        listOf(
+            Activity(
+                "Advanced Markers",
+                "Adding advanced markers to your map.",
+                AdvancedMarkersActivity::class
+            ),
+            Activity(
+                "Marker Clustering",
+                "Clustering markers on your map.",
+                MarkerClusteringActivity::class
+            ),
+            Activity(
+                "Marker Drag Events",
+                "Listening to marker drag events.",
+                MarkerDragEventsActivity::class
+            ),
+            Activity(
+                "Markers Collection",
+                "Adding a collection of markers to your map.",
+                MarkersCollectionActivity::class
+            ),
+            Activity(
+                "Syncing Draggable Marker With Data Model",
+                "Keeping a draggable marker in sync with a data model.",
+                SyncingDraggableMarkerWithDataModelActivity::class
+            ),
+            Activity(
+                "Updating No-Drag Marker With Data Model",
+                "Updating a non-draggable marker with a data model.",
+                UpdatingNoDragMarkerWithDataModelActivity::class
+            ),
+            Activity(
+                "Draggable Markers Collection With Polygon",
+                "Dragging a collection of markers that form a polygon.",
+                DraggableMarkersCollectionWithPolygonActivity::class
+            ),
+        )
+    )
+
+    object UIIntegration : ActivityGroup(
+        "UI Integration",
+        listOf(
+            Activity(
+                "Map in Column",
+                "Displaying a map within a column.",
+                MapInColumnActivity::class
+            ),
+            Activity(
+                "Maps in LazyColumn",
+                "Displaying multiple maps in a LazyColumn.",
+                MapsInLazyColumnActivity::class
+            ),
+            Activity(
+                "Fragment Demo",
+                "Using the map compose components in a fragment.",
+                FragmentDemoActivity::class
+            ),
+        )
+    )
+
+    object Performance : ActivityGroup(
+        "Performance",
+        listOf(
+            Activity(
+                "Recomposition",
+                "Understanding how recomposition works with maps.",
+                RecompositionActivity::class
+            ),
+        )
+    )
+}
+
+/**
+ * A data class representing a single demo activity. This class serves as a model for each
+ * item in the demo list.
+ *
+ * @param title The title of the activity.
+ * @param description A short description of what the demo showcases.
+ * @param kClass The class of the activity to be launched.
+ */
+data class Activity(
+    val title: String,
+    val description: String,
+    val kClass: KClass<out ComponentActivity>
+)
+
+/**
+ * The single source of truth for all the demo activity groups. This list is used to populate
+ * the main screen.
+ */
+val allActivityGroups = listOf(
+    ActivityGroup.MapTypes,
+    ActivityGroup.MapFeatures,
+    ActivityGroup.Markers,
+    ActivityGroup.UIIntegration,
+    ActivityGroup.Performance,
+)
+
+/**
+ * A composable function that displays a collapsible list of demo activity groups. This is the
+ * main UI component for the main screen.
+ *
+ * The list is built using a `LazyColumn` for performance, ensuring that only the visible items
+ * are rendered. Each group is represented by a clickable `Card` that expands or collapses to
+ * reveal the activities within it. This approach keeps the UI clean and organized, especially
+ * with a large number of demos.
+ *
+ * @param onActivityClick A lambda function to be invoked when a demo activity is clicked. This
+ *                        allows the navigation logic to be decoupled from the UI.
+ */
+@Composable
+fun DemoList(
+    onActivityClick: (KClass<out ComponentActivity>) -> Unit
+) {
+    // State to keep track of the currently expanded group.
+    var expandedGroup by remember { mutableStateOf<ActivityGroup?>(null) }
+
+    LazyColumn {
+        items(allActivityGroups) { group ->
+            Column {
+                // The card representing the group header.
+                Card(
+                    // Highlight the card when it's expanded.
+                    colors = if (expandedGroup == group) {
+                        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+                    } else {
+                        CardDefaults.cardColors()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                        .clickable {
+                            // Toggle the expanded state of the group.
+                            expandedGroup = if (expandedGroup == group) null else group
+                        }
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = group.title,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.weight(1f)
+                        )
+                        // Show an up or down arrow to indicate the expanded/collapsed state.
+                        Icon(
+                            imageVector = if (expandedGroup == group) {
+                                Icons.Default.KeyboardArrowUp
+                            } else {
+                                Icons.Default.KeyboardArrowDown
+                            },
+                            contentDescription = null
+                        )
+                    }
+                }
+
+                // Animate the visibility of the activities within the group.
+                AnimatedVisibility(visible = expandedGroup == group) {
+                    Column(
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+                    ) {
+                        // Create a card for each activity in the group.
+                        group.activities.forEach { activity ->
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp)
+                                    .clickable { onActivityClick(activity.kClass) }
+                            ) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    Text(text = activity.title, fontWeight = FontWeight.Bold)
+                                    Text(text = activity.description)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/maps-app/src/main/java/com/google/maps/android/compose/MainActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/MainActivity.kt
@@ -25,23 +25,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.google.maps.android.compose.markerexamples.AdvancedMarkersActivity
-import com.google.maps.android.compose.markerexamples.MarkerClusteringActivity
-import com.google.maps.android.compose.markerexamples.draggablemarkerscollectionwithpolygon.DraggableMarkersCollectionWithPolygonActivity
-import com.google.maps.android.compose.markerexamples.markerdragevents.MarkerDragEventsActivity
-import com.google.maps.android.compose.markerexamples.markerscollection.MarkersCollectionActivity
-import com.google.maps.android.compose.markerexamples.syncingdraggablemarkerwithdatamodel.SyncingDraggableMarkerWithDataModelActivity
-import com.google.maps.android.compose.markerexamples.updatingnodragmarkerwithdatamodel.UpdatingNoDragMarkerWithDataModelActivity
 import com.google.maps.android.compose.theme.MapsComposeSampleTheme
 
 class MainActivity : ComponentActivity() {
@@ -61,160 +51,24 @@ class MainActivity : ComponentActivity() {
         setContent {
             MapsComposeSampleTheme {
                 Surface(
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .fillMaxSize()
                         .systemBarsPadding(),
-                    color = MaterialTheme.colors.background
+                    color = MaterialTheme.colorScheme.background
                 ) {
                     val context = LocalContext.current
                     Column(
-                        Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState()),
+                        Modifier.fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Spacer(modifier = Modifier.padding(10.dp))
                         Text(
                             text = getString(R.string.main_activity_title),
-                            style = MaterialTheme.typography.h5
+                            style = MaterialTheme.typography.titleMedium
                         )
                         Spacer(modifier = Modifier.padding(10.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, BasicMapActivity::class.java))
-                            }) {
-                            Text(getString(R.string.basic_map_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, AdvancedMarkersActivity::class.java))
-                            }) {
-                            Text(getString(R.string.advanced_markers))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(
-                                    Intent(
-                                        context,
-                                        MarkerClusteringActivity::class.java
-                                    )
-                                )
-                            }) {
-                            Text(getString(R.string.marker_clustering_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(
-                                    Intent(
-                                        context,
-                                        MapInColumnActivity::class.java
-                                    )
-                                )
-                            }) {
-                            Text(getString(R.string.map_in_column_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(
-                                    Intent(
-                                        context,
-                                        MapsInLazyColumnActivity::class.java
-                                    )
-                                )
-                            }) {
-                            Text(getString(R.string.maps_in_lazy_column_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(
-                                    Intent(
-                                        context,
-                                        LocationTrackingActivity::class.java
-                                    )
-                                )
-                            }) {
-                            Text(getString(R.string.location_tracking_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, ScaleBarActivity::class.java))
-                            }) {
-                            Text(getString(R.string.scale_bar_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, StreetViewActivity::class.java))
-                            }) {
-                            Text(getString(R.string.street_view))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, CustomControlsActivity::class.java))
-                            }) {
-                            Text(getString(R.string.custom_location_button))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, AccessibilityActivity::class.java))
-                            }) {
-                            Text(getString(R.string.accessibility_button))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, RecompositionActivity::class.java))
-                            }) {
-                            Text(getString(R.string.recomposition_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, MarkerDragEventsActivity::class.java))
-                            }) {
-                            Text(getString(R.string.marker_drag_events_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, MarkersCollectionActivity::class.java))
-                            }) {
-                            Text(getString(R.string.markers_collection_activity))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, SyncingDraggableMarkerWithDataModelActivity::class.java))
-                            }) {
-                            Text(getString(R.string.syncing_draggable_marker_with_data_model))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, UpdatingNoDragMarkerWithDataModelActivity::class.java))
-                            }) {
-                            Text(getString(R.string.updating_non_draggable_marker_with_data_model))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, DraggableMarkersCollectionWithPolygonActivity::class.java))
-                            }) {
-                            Text(getString(R.string.draggable_markers_collection_with_polygon))
-                        }
-                        Spacer(modifier = Modifier.padding(5.dp))
-                        Button(
-                            onClick = {
-                                context.startActivity(Intent(context, FragmentDemoActivity::class.java))
-                            }) {
-                            Text(getString(R.string.fragment_demo_activity))
+                        DemoList {
+                            context.startActivity(Intent(context, it.java))
                         }
                     }
                 }


### PR DESCRIPTION
Group demo activities on main screen and export all activities in the manifest.

To make the main screen less cluttered and easier to navigate, the demo activities have been grouped into a list.
This provides a cleaner and more organized user experience.

This change also pulls in Material 3.
