### PR TITLE
build: upgrade node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
           GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
           GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: '24.7.0'
 
       - name: Install conventionalcommits
         run: npm i -D conventional-changelog-conventionalcommits


### PR DESCRIPTION
This PR upgrades the node version.

The latest semantic-versioning version fails. There is a new `actions/setup-node` version, checking if this fixes it.