### PR TITLE
build: rollback semantic-versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,15 @@ jobs:
           GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
           GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
-          node-version: '24.7.0'
+          node-version: '14'
 
       - name: Install conventionalcommits
         run: npm i -D conventional-changelog-conventionalcommits
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v5.0.0
+        uses: cycjimmy/semantic-release-action@v4.2.1
         with:
           extra_plugins: |
             "@semantic-release/commit-analyzer@8.0.1"


### PR DESCRIPTION
This PR rolls back the semantic-versioning and the node version