### PR TITLE
chore: rename and fix flow

### DIFF
--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -12,24 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Dependabot
+name: Automerge Docs
 on: pull_request
 
 permissions:
   contents: write
 
 jobs:
-  test:
-    uses: ./.github/workflows/test.yml
-  dependabot:
-    needs: test
+  automerge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'googlemaps-bot' }}
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{secrets.SYNCED_GITHUB_TOKEN_REPO}}
     steps:
-      - name: approve
+      - name: approve PR
         run: gh pr review --approve "$PR_URL"
       - name: merge
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
This PR renames the file (it is not checking dependabot to merge it, but the documentation), and removes the need to run the test again, which is redundant and not necessary to merge into `gh-pages`.