### PR TITLE
feat!: updated Compose version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-activitycompose = "1.11.0"
+activitycompose = "1.12.1"
 agp = "8.13.1"
 androidCore = "1.7.0"
 androidx-core = "1.17.0"

--- a/maps-app/build.gradle.kts
+++ b/maps-app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"

--- a/maps-compose-utils/build.gradle.kts
+++ b/maps-compose-utils/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
     }
 
     compileOptions {

--- a/maps-compose-widgets/build.gradle.kts
+++ b/maps-compose-widgets/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/maps-compose/build.gradle.kts
+++ b/maps-compose/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
     }
 
     compileOptions {


### PR DESCRIPTION
This PR updates the Compose [version to 1.10](https://android-developers.googleblog.com/2025/12/whats-new-in-jetpack-compose-december.html) to introduce some performance improvements.

This is a breaking change, since we need to update the [minSdk to 23](https://developer.android.com/jetpack/androidx/versions#version-table).