### PR TITLE
build: downgrade node version to 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - name: Install conventionalcommits
         run: npm i -D conventional-changelog-conventionalcommits


### PR DESCRIPTION
The current PR downgrades the node version from 20 to 18.