### PR TITLE
build: change docs flow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,8 @@
 name: Update documentation
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [published]
   repository_dispatch:
       types: [gh-pages]
   workflow_dispatch:


### PR DESCRIPTION
The following PR changes the docs flow to run **only** after a release has been published.