### PR TITLE
fix: clustering idle timeout

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -94,9 +94,17 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
      */
     private fun Cluster<T>.computeViewKeys(): Set<ViewKey<T>> {
         return if (shouldRenderAsCluster(this)) {
-            setOf(ViewKey.Cluster(this))
+            if (clusterContentState.value != null) {
+                setOf(ViewKey.Cluster(this))
+            } else {
+                emptySet()
+            }
         } else {
-            items.mapTo(mutableSetOf()) { ViewKey.Item(it) }
+            if (clusterItemContentState.value != null) {
+                items.mapTo(mutableSetOf()) { ViewKey.Item(it) }
+            } else {
+                emptySet()
+            }
         }
     }
 


### PR DESCRIPTION
ComposeUiClusterRenderer incorrectly created empty ComposeViews for clusters even when clusterContent was null, which kept the composition busy and caused test timeouts; this PR ensures ViewKeys are only generated when custom content is provided.

Fixes #579 
