### PR TITLE
fix: prevent NoSuchElementException when computing view keys in ClusterRenderer

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -180,8 +180,14 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
             val viewInfo = keysToViews.entries
                 .firstOrNull { (key, _) -> (key as? ViewKey.Cluster)?.cluster == cluster }
                 ?.value
-                ?: createAndAddView(cluster.computeViewKeys().first())
-            renderViewToBitmapDescriptor(viewInfo.view)
+
+            if (viewInfo != null) {
+                renderViewToBitmapDescriptor(viewInfo.view)
+            } else {
+                cluster.computeViewKeys().firstOrNull()?.let { key ->
+                    renderViewToBitmapDescriptor(createAndAddView(key).view)
+                } ?: super.getDescriptorForCluster(cluster)
+            }
         } else {
             super.getDescriptorForCluster(cluster)
         }


### PR DESCRIPTION
This PR fixes a `NoSuchElementException` in `ComposeUiClusterRenderer.getDescriptorForCluster` that occurs when the internal collection of view keys is empty. 

**What happens:**
During rapid updates to clustering (often when zooming in/out quickly or managing large data sets with custom Compose content), a race condition can cause the map to try to render a cluster before its Compose view is fully ready. The code previously called `cluster.computeViewKeys().first()`, which crashes the app if the collection is empty.

**How this PR fixes it:**
Instead of blindly calling `.first()`, the code now uses `.firstOrNull()`. If a view key is found, it renders it as expected. If the collection is momentarily empty, it falls back gracefully to `super.getDescriptorForCluster(cluster)`, allowing the app to render the default cluster marker instead of crashing.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #393 🦕
Fixes #271
