### PR TITLE
fix: fixed issue with ProGuard/R8 and AttributionId

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/utils/attribution/AttributionIdInitializer.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/utils/attribution/AttributionIdInitializer.kt
@@ -17,6 +17,7 @@
 package com.google.maps.android.compose.utils.attribution
 
 import android.content.Context
+import androidx.annotation.Keep
 import androidx.startup.Initializer
 import com.google.android.gms.maps.MapsApiSettings
 import com.google.maps.android.compose.utils.meta.AttributionId
@@ -26,6 +27,7 @@ import com.google.maps.android.compose.utils.meta.AttributionId
  * and samples are helpful to developers, such as usage of this library.
  * To opt out of sending the usage attribution ID, please remove this initializer from your manifest.
  */
+@Keep
 internal class AttributionIdInitializer : Initializer<Unit> {
     override fun create(context: Context) {
         MapsApiSettings.addInternalUsageAttributionId(


### PR DESCRIPTION
This PR ads the `@Keep` annotation to the `AttributionIdInitializer` to prevent R8 from stripping the class, which resolving startup crashes caused by `AppInitializer` failing to instantiate the component via reflection.