### PR TITLE
docs: improve nested scroll explanation in LazyColumn

### DIFF
--- a/maps-app/src/main/java/com/google/maps/android/compose/MapsInLazyColumnActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/MapsInLazyColumnActivity.kt
@@ -290,6 +290,15 @@ private fun MapCard(
             }
 
             Column(
+                modifier = Modifier.align(Alignment.TopStart)
+            ) {
+                TextWithBackground(
+                    "Panning this map disables list scroll",
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Column(
                 modifier = Modifier.align(Alignment.BottomStart)
             ) {
                 TextWithBackground(item.title, fontWeight = FontWeight.Bold)


### PR DESCRIPTION
This PR updates the MapsInLazyColumnActivity sample to make the solution for nested scrolling more explicit.

**Changes:**
- Added a header to each MapCard that says 'Panning this map disables list scroll'.
- This visually reinforces the userScrollEnabled = !anyMapMoving logic already present in the sample, making it a better reference for developers investigating nested scroll issues.

Relates to: https://github.com/googlemaps/android-maps-compose/issues/14