### PR TITLE
chore: clean up unused imports and address lint warnings

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -27,6 +27,7 @@ import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
 import androidx.core.view.doOnAttach
 import androidx.core.view.doOnDetach
 import androidx.compose.ui.geometry.Offset
@@ -37,7 +38,6 @@ import com.google.android.gms.maps.model.MarkerOptions
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.ClusterItem
 import com.google.maps.android.clustering.ClusterManager
-import com.google.maps.android.clustering.view.ClusterRenderer
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
 import com.google.maps.android.compose.ComposeUiViewRenderer
 import kotlinx.coroutines.CoroutineScope
@@ -250,17 +250,16 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
            so trigger a draw to an empty canvas to force that */
         view.draw(fakeCanvas)
         val viewParent =
-            view.parent as? ViewGroup ?: return Bitmap.createBitmap(20, 20, Bitmap.Config.ARGB_8888)
+            view.parent as? ViewGroup ?: return createBitmap(20, 20)
                 .let(BitmapDescriptorFactory::fromBitmap)
         view.measure(
             View.MeasureSpec.makeMeasureSpec(viewParent.width, View.MeasureSpec.AT_MOST),
             View.MeasureSpec.makeMeasureSpec(viewParent.height, View.MeasureSpec.AT_MOST),
         )
         view.layout(0, 0, view.measuredWidth, view.measuredHeight)
-        val bitmap = Bitmap.createBitmap(
+        val bitmap = createBitmap(
             view.measuredWidth.takeIf { it > 0 } ?: 1,
-            view.measuredHeight.takeIf { it > 0 } ?: 1,
-            Bitmap.Config.ARGB_8888
+            view.measuredHeight.takeIf { it > 0 } ?: 1
         )
         bitmap.applyCanvas {
             view.draw(this)

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/Clustering.kt
@@ -28,10 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.UiComposable
@@ -43,7 +40,6 @@ import com.google.maps.android.clustering.ClusterItem
 import com.google.maps.android.clustering.ClusterManager
 import com.google.maps.android.clustering.view.ClusterRenderer
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
-import com.google.maps.android.collections.MarkerManager
 import com.google.maps.android.compose.GoogleMapComposable
 import com.google.maps.android.compose.InputHandler
 import com.google.maps.android.compose.MapEffect
@@ -372,9 +368,10 @@ internal fun <T : ClusterItem> Clustering(
     }
 
     val actualRenderer = renderer ?: clusterManager.renderer
+    @Suppress("UNCHECKED_CAST")
     val unclusteredItems by (actualRenderer as? ClusterRendererItemState<T>)?.unclusteredItems
         ?: remember { mutableStateOf(emptySet()) }
-    unclusteredItems.forEach { item ->
+    for (item in unclusteredItems) {
         clusterItemDecoration(item)
     }
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/wms/WmsUrlTileProvider.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/wms/WmsUrlTileProvider.kt
@@ -20,7 +20,6 @@ import com.google.android.gms.maps.model.UrlTileProvider
 import java.net.MalformedURLException
 import java.net.URL
 import kotlin.math.PI
-import kotlin.math.pow
 
 /**
  * A [UrlTileProvider] for Web Map Service (WMS) layers that use the EPSG:3857 (Web Mercator)

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -33,7 +33,6 @@ import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.lang.Integer.MAX_VALUE

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,7 +36,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle

--- a/maps-compose/src/main/java/com/google/maps/android/compose/InputHandler.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/InputHandler.kt
@@ -26,7 +26,6 @@ import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.GroundOverlay
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.Polygon
-import com.google.android.gms.maps.GoogleMap.OnMarkerClickListener
 import com.google.android.gms.maps.model.Polyline
 
 /**

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapComposeViewRender.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapComposeViewRender.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.ui.platform.AbstractComposeView
-import androidx.compose.ui.platform.ComposeView
 import com.google.android.gms.maps.MapView
 import java.io.Closeable
 

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapEffect.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapEffect.kt
@@ -17,7 +17,6 @@
 package com.google.maps.android.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.currentComposer
 import com.google.android.gms.maps.GoogleMap

--- a/maps-compose/src/main/java/com/google/maps/android/compose/ReattachClickListeners.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/ReattachClickListeners.kt
@@ -20,7 +20,6 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.remember
-import com.google.android.gms.maps.GoogleMap
 
 /**
  * Returns a lambda that, when invoked, will reattach click listeners set by the [MapApplier] on

--- a/maps-compose/src/main/java/com/google/maps/android/compose/streetview/StreetViewPanoramaEventListeners.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/streetview/StreetViewPanoramaEventListeners.kt
@@ -19,7 +19,6 @@ package com.google.maps.android.compose.streetview
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.google.android.gms.maps.model.StreetViewPanoramaCamera
 import com.google.android.gms.maps.model.StreetViewPanoramaOrientation
 
 /**


### PR DESCRIPTION
- Remove unused and duplicate imports in multiple files.
- Suppress unchecked cast in Clustering.kt.
- Refactor loops and bitmap creation for better performance and style.