### PR TITLE
build: migrate to AGP 9 and built-in Kotlin support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,5 +42,4 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,21 +3,21 @@
 
 [versions]
 # Base
-androidCompileSdk = "36"
+androidCompileSdk = "37"
 androidMinSdk = "23"
-androidTargetSdk = "36"
+androidTargetSdk = "37"
 
-agp = "9.1.0"
-dokka = "2.1.0"
+agp = "9.2.1"
+dokka = "2.2.0"
 gradleMavenPublishPlugin = "0.36.0"
-kotlin = "2.3.10"
+kotlin = "2.3.21"
 kotlinxCoroutines = "1.10.2"
 
 # Android
 activitycompose = "1.13.0"
 androidx-core = "1.18.0"
 androidx-startup = "1.2.0"
-compose-bom = "2026.03.00"
+compose-bom = "2026.05.00"
 constraintlayout = "2.2.1"
 
 # Material
@@ -40,7 +40,7 @@ mockk = "1.14.9"
 org-jacoco-core = "0.8.14"
 jacoco-plugin = "0.2.1"
 robolectric = "4.16.1"
-screenshot = "0.0.1-alpha13"
+screenshot = "0.0.1-alpha14"
 truth = "1.4.5"
 
 [libraries]
@@ -85,7 +85,6 @@ jacoco-android-plugin = { module = "com.mxalbert.gradle:jacoco-android", version
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-#mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinxCoroutines = "1.10.2"
 activitycompose = "1.13.0"
 androidx-core = "1.18.0"
 androidx-startup = "1.2.0"
-compose-bom = "2026.05.00"
+compose-bom = "2026.03.00"
 constraintlayout = "2.2.1"
 
 # Material

--- a/maps-app/build.gradle.kts
+++ b/maps-app/build.gradle.kts
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.screenshot)
@@ -63,21 +62,8 @@ android {
         compose = true
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-            freeCompilerArgs.addAll(
-                "-opt-in=kotlin.RequiresOptIn"
-            )
-        }
-    }
-
+    @Suppress("UnstableApiUsage")
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
-
-    screenshotTests {
-        imageDifferenceThreshold = 0.035f // 3.5%
-    }
-
 
     packaging {
         resources {
@@ -87,6 +73,19 @@ android {
             )
         }
     }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.addAll(
+            "-opt-in=kotlin.RequiresOptIn"
+        )
+    }
+}
+
+screenshotTests {
+    imageDifferenceThreshold = 0.035f // 3.5%
 }
 
 dependencies {

--- a/maps-app/src/main/java/com/google/maps/android/compose/GroundOverlayActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/GroundOverlayActivity.kt
@@ -15,7 +15,7 @@
 package com.google.maps.android.compose
 
 import android.os.Bundle
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -156,7 +156,7 @@ fun GroundOverlayControls(
                 Text(text = "Visible", modifier = Modifier.weight(1f))
                 Switch(checked = isVisible, onCheckedChange = onVisibilityChange)
             }
-            Text(text = "Transparency: ${String.format(androidx.compose.ui.text.intl.Locale.current.platformLocale, "%.2f", transparency)}")
+            Text(text = "Transparency: ${String.format(Locale.current.platformLocale, "%.2f", transparency)}")
             Slider(
                 value = transparency,
                 onValueChange = onTransparencyChange,

--- a/maps-app/src/main/java/com/google/maps/android/compose/GroundOverlayActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/GroundOverlayActivity.kt
@@ -156,7 +156,7 @@ fun GroundOverlayControls(
                 Text(text = "Visible", modifier = Modifier.weight(1f))
                 Switch(checked = isVisible, onCheckedChange = onVisibilityChange)
             }
-            Text(text = "Transparency: ${String.format(Locale.getDefault(), "%.2f", transparency)}")
+            Text(text = "Transparency: ${String.format(androidx.compose.ui.text.intl.Locale.current.platformLocale, "%.2f", transparency)}")
             Slider(
                 value = transparency,
                 onValueChange = onTransparencyChange,

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
@@ -18,7 +18,7 @@ package com.google.maps.android.compose.markerexamples
 
 import android.os.Bundle
 import android.util.Log
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -205,7 +205,7 @@ private fun CustomUiClustering(items: List<MyItem>) {
         clusterContent = { cluster ->
             CircleContent(
                 modifier = Modifier.size(40.dp),
-                text = "%,d".format(androidx.compose.ui.text.intl.Locale.current.platformLocale, cluster.size),
+                text = "%,d".format(Locale.current.platformLocale, cluster.size),
                 color = Color.Blue,
             )
         },
@@ -252,7 +252,7 @@ fun CustomRendererClustering(items: List<MyItem>) {
         clusterContent = { cluster ->
             CircleContent(
                 modifier = Modifier.size(40.dp),
-                text = "%,d".format(androidx.compose.ui.text.intl.Locale.current.platformLocale, cluster.size),
+                text = "%,d".format(Locale.current.platformLocale, cluster.size),
                 color = Color.Green,
             )
         },

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
@@ -205,7 +205,7 @@ private fun CustomUiClustering(items: List<MyItem>) {
         clusterContent = { cluster ->
             CircleContent(
                 modifier = Modifier.size(40.dp),
-                text = "%,d".format(Locale.getDefault(), cluster.size),
+                text = "%,d".format(androidx.compose.ui.text.intl.Locale.current.platformLocale, cluster.size),
                 color = Color.Blue,
             )
         },
@@ -252,7 +252,7 @@ fun CustomRendererClustering(items: List<MyItem>) {
         clusterContent = { cluster ->
             CircleContent(
                 modifier = Modifier.size(40.dp),
-                text = "%,d".format(Locale.getDefault(), cluster.size),
+                text = "%,d".format(androidx.compose.ui.text.intl.Locale.current.platformLocale, cluster.size),
                 color = Color.Green,
             )
         },

--- a/maps-compose-utils/build.gradle.kts
+++ b/maps-compose-utils/build.gradle.kts
@@ -17,7 +17,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin-android")
     alias(libs.plugins.compose.compiler)
     id("android.maps.compose.PublishingConventionPlugin")
     id("org.jetbrains.dokka")
@@ -45,21 +44,21 @@ android {
         compose = true
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-            freeCompilerArgs.addAll(
-                "-Xexplicit-api=strict",
-                "-opt-in=kotlin.RequiresOptIn"
-            )
-        }
-    }
-
     buildTypes {
         getByName("debug") {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.addAll(
+            "-Xexplicit-api=strict",
+            "-opt-in=kotlin.RequiresOptIn"
+        )
     }
 }
 

--- a/maps-compose-widgets/build.gradle.kts
+++ b/maps-compose-widgets/build.gradle.kts
@@ -17,7 +17,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin-android")
     alias (libs.plugins.compose.compiler)
     id("android.maps.compose.PublishingConventionPlugin")
     id("org.jetbrains.dokka")
@@ -53,21 +52,21 @@ android {
         compose = true
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-            freeCompilerArgs.addAll(
-                "-Xexplicit-api=strict",
-                "-opt-in=kotlin.RequiresOptIn"
-            )
-        }
-    }
-
     buildTypes {
         getByName("debug") {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.addAll(
+            "-Xexplicit-api=strict",
+            "-opt-in=kotlin.RequiresOptIn"
+        )
     }
 }
 

--- a/maps-compose/build.gradle.kts
+++ b/maps-compose/build.gradle.kts
@@ -17,7 +17,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.jetbrains.kotlin.android")
     alias(libs.plugins.compose.compiler)
     id("org.jetbrains.dokka")
     id("android.maps.compose.PublishingConventionPlugin")
@@ -45,23 +44,28 @@ android {
         compose = true
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-            freeCompilerArgs.addAll(
-                "-Xexplicit-api=strict",
-                "-opt-in=kotlin.RequiresOptIn"
-            )
+    sourceSets {
+        getByName("main") {
+            java.directories.add("build/generated/source/artifactId")
+            kotlin.directories.add("build/generated/source/artifactId")
         }
     }
-
-    sourceSets["main"].java.srcDir("build/generated/source/artifactId")
 
     buildTypes {
         getByName("debug") {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.addAll(
+            "-Xexplicit-api=strict",
+            "-opt-in=kotlin.RequiresOptIn"
+        )
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 rootProject.name = "android-maps-compose"
 
 include(":maps-app")


### PR DESCRIPTION
This PR updates the project to correctly use AGP 9.0+ features and conventions:

- Removes the deprecated `kotlin-android` plugin and migrates to built-in Kotlin support.
- Removes deprecated `srcDir` usages in favor of `directories.add()`.
- Adds explicitly generated source paths to the `kotlin` sourceSet so `AttributionId` builds properly.
- Fixes 'Suspicious receiver type' warnings by moving `kotlin` and `screenshotTests` blocks outside the `android` block to the correct project scope.
- Suppresses UnstableApiUsage warning for `experimentalProperties` usage.