### PR TITLE
fix: toggle map color scheme from system state

### DIFF
--- a/maps-app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/BasicMapActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -167,6 +168,7 @@ fun GoogleMapView(
     var mapVisible by remember { mutableStateOf(true) }
 
     var darkMode by remember { mutableStateOf(mapColorScheme) }
+    val systemInDarkTheme = isSystemInDarkTheme()
 
     if (mapVisible) {
         GoogleMap(
@@ -303,11 +305,7 @@ fun GoogleMapView(
             MapButton(
                 text = "Toggle Dark Mode",
                 onClick = {
-                    darkMode =
-                        if (darkMode == ComposeMapColorScheme.DARK)
-                            ComposeMapColorScheme.LIGHT
-                        else
-                            ComposeMapColorScheme.DARK
+                    darkMode = toggledMapColorScheme(darkMode, systemInDarkTheme)
                 },
                 modifier = Modifier
                     .testTag("toggleDarkMode")
@@ -344,6 +342,19 @@ fun GoogleMapView(
             }
         )
         DebugView(cameraPositionState, singaporeState)
+    }
+}
+
+internal fun toggledMapColorScheme(
+    current: ComposeMapColorScheme,
+    systemInDarkTheme: Boolean,
+): ComposeMapColorScheme = when (current) {
+    ComposeMapColorScheme.LIGHT -> ComposeMapColorScheme.DARK
+    ComposeMapColorScheme.DARK -> ComposeMapColorScheme.LIGHT
+    ComposeMapColorScheme.FOLLOW_SYSTEM -> if (systemInDarkTheme) {
+        ComposeMapColorScheme.LIGHT
+    } else {
+        ComposeMapColorScheme.DARK
     }
 }
 

--- a/maps-app/src/test/java/com/google/maps/android/compose/BasicMapActivityTest.kt
+++ b/maps-app/src/test/java/com/google/maps/android/compose/BasicMapActivityTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.compose
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BasicMapActivityTest {
+
+    @Test
+    fun lightSchemeTogglesToDark() {
+        val result = toggledMapColorScheme(
+            current = ComposeMapColorScheme.LIGHT,
+            systemInDarkTheme = false,
+        )
+
+        assertThat(result).isEqualTo(ComposeMapColorScheme.DARK)
+    }
+
+    @Test
+    fun darkSchemeTogglesToLight() {
+        val result = toggledMapColorScheme(
+            current = ComposeMapColorScheme.DARK,
+            systemInDarkTheme = true,
+        )
+
+        assertThat(result).isEqualTo(ComposeMapColorScheme.LIGHT)
+    }
+
+    @Test
+    fun followSystemTogglesAwayFromEffectiveScheme() {
+        assertThat(
+            toggledMapColorScheme(
+                current = ComposeMapColorScheme.FOLLOW_SYSTEM,
+                systemInDarkTheme = false,
+            )
+        ).isEqualTo(ComposeMapColorScheme.DARK)
+        assertThat(
+            toggledMapColorScheme(
+                current = ComposeMapColorScheme.FOLLOW_SYSTEM,
+                systemInDarkTheme = true,
+            )
+        ).isEqualTo(ComposeMapColorScheme.LIGHT)
+    }
+}


### PR DESCRIPTION
## Summary
- Make the first sample dark-mode toggle switch away from the effective system scheme.
- Preserve explicit LIGHT and DARK toggling behavior.
- Add unit coverage for light, dark, and FOLLOW_SYSTEM transitions.

## Root cause
The sample initializes the map with FOLLOW_SYSTEM, but its first button press always selected DARK. On an API 37 emulator already using dark theme, that is visually DARK to DARK, so the map appears not to react even though Compose state updates. The library runtime mapColorScheme propagation is unchanged.

## Verification
- [x] git diff --check
- [x] Focused unit tests added in BasicMapActivityTest
- [ ] Local Gradle test/build: blocked by the Codex host sandbox denying the Gradle file-lock socket
- [ ] API 37 before/after screenshots: blocked because no Maps API key is available in the environment

CI is expected to run the repository build, unit tests, screenshot tests, lint, and instrumentation suite.

Fixes #917