### PR TITLE
build: add RC release workflow

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release RC
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'RC version (e.g. 8.3.0-rc01)'
+        required: true
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: write
+
+jobs:
+  release-rc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version files
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # .release-please-manifest.json
+          sed -i 's/"\." *: *"[^"]*"/".": "'"$VERSION"'"/' .release-please-manifest.json
+
+          # build.gradle.kts (between release-please markers)
+          sed -i 's/version = "[^"]*"/version = "'"$VERSION"'"/' build.gradle.kts
+
+          # Files with x-release-please-version inline marker
+          for file in README.md llm-integration-prompt.md .gemini/skills/android-maps-compose/SKILL.md; do
+            if [ -f "$file" ]; then
+              sed -i "/x-release-please-version/s/[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[a-zA-Z0-9.-]*/$VERSION/" "$file"
+            fi
+          done
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git add \
+            .release-please-manifest.json \
+            build.gradle.kts \
+            README.md \
+            llm-integration-prompt.md \
+            .gemini/skills/android-maps-compose/SKILL.md
+          git commit -m "chore: release v${VERSION}"
+          git push origin "${{ inputs.branch }}"
+
+      - name: Tag and create pre-release
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+        run: |
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+          # Find the previous tag to use as baseline for release notes
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged HEAD | grep -v "v${VERSION}" | head -1)
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --notes-start-tag "$PREVIOUS_TAG" \
+              --prerelease
+          else
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --prerelease
+          fi


### PR DESCRIPTION
## Summary
Adds a new release candidate (RC) workflow for android-maps-compose, enabling automated RC releases with proper changelog generation.

## Changes
- New `release-rc.yml` workflow for manual RC triggers
- Compares release notes against the previous RC tag (not main branch)
- Updates version in `.release-please-manifest.json`, `build.gradle.kts`, and associated doc files
- Publishes as a GitHub pre-release

## How to use
Trigger via GitHub Actions workflow dispatch with:
- **version**: RC version (e.g., 8.3.0-rc01)
- **branch**: Branch to release from (default: main)

## Release notes behavior
- RC01: diff between last stable release and RC01
- RC02: diff between RC01 and RC02
- RC03: diff between RC02 and RC03