### PR TITLE
fix(deps): update dependencies across android-maps-compose

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,14 +10,14 @@ androidTargetSdk = "37"
 agp = "9.2.1"
 dokka = "2.2.0"
 gradleMavenPublishPlugin = "0.36.0"
-kotlin = "2.3.21"
-kotlinxCoroutines = "1.10.2"
+kotlin = "2.4.0"
+kotlinxCoroutines = "1.11.0"
 
 # Android
 activitycompose = "1.13.0"
-androidx-core = "1.18.0"
+androidx-core = "1.19.0"
 androidx-startup = "1.2.0"
-compose-bom = "2026.03.00"
+compose-bom = "2026.06.01"
 constraintlayout = "2.2.1"
 
 # Material
@@ -27,7 +27,7 @@ materialIconsExtendedAndroid = "1.7.8"
 
 # Google Maps Platform
 mapsecrets = "2.0.1"
-mapsktx = "6.0.1"
+mapsktx = "6.1.0"
 
 # Testing
 androidCore = "1.7.0"
@@ -36,8 +36,8 @@ espresso = "3.7.0"
 junit = "4.13.2"
 junitktx = "1.3.0"
 leakcanaryAndroid = "2.14"
-mockk = "1.14.9"
-org-jacoco-core = "0.8.14"
+mockk = "1.14.11"
+org-jacoco-core = "0.8.15"
 jacoco-plugin = "0.2.1"
 robolectric = "4.16.1"
 screenshot = "0.0.1-alpha14"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ androidTargetSdk = "37"
 agp = "9.2.1"
 dokka = "2.2.0"
 gradleMavenPublishPlugin = "0.36.0"
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 kotlinxCoroutines = "1.11.0"
 
 # Android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ materialIconsExtendedAndroid = "1.7.8"
 
 # Google Maps Platform
 mapsecrets = "2.0.1"
-mapsktx = "6.1.0"
+mapsktx = "6.2.0"
 
 # Testing
 androidCore = "1.7.0"

--- a/maps-app/build.gradle.kts
+++ b/maps-app/build.gradle.kts
@@ -53,8 +53,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -77,7 +77,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
+        jvmTarget.set(JvmTarget.JVM_11)
         freeCompilerArgs.addAll(
             "-opt-in=kotlin.RequiresOptIn"
         )

--- a/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/markerexamples/MarkerClusteringActivity.kt
@@ -383,20 +383,8 @@ private enum class ClusteringType {
 }
 
 data class MyItem(
-    val itemPosition: LatLng,
-    val itemTitle: String,
-    val itemSnippet: String,
-    val itemZIndex: Float,
-) : ClusterItem {
-    override fun getPosition(): LatLng =
-        itemPosition
-
-    override fun getTitle(): String =
-        itemTitle
-
-    override fun getSnippet(): String =
-        itemSnippet
-
-    override fun getZIndex(): Float =
-        itemZIndex
-}
+    override val position: LatLng,
+    override val title: String,
+    override val snippet: String,
+    override val zIndex: Float,
+) : ClusterItem

--- a/maps-compose-utils/build.gradle.kts
+++ b/maps-compose-utils/build.gradle.kts
@@ -35,8 +35,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -54,7 +54,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
+        jvmTarget.set(JvmTarget.JVM_11)
         freeCompilerArgs.addAll(
             "-Xexplicit-api=strict",
             "-opt-in=kotlin.RequiresOptIn"

--- a/maps-compose-widgets/build.gradle.kts
+++ b/maps-compose-widgets/build.gradle.kts
@@ -43,8 +43,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -62,7 +62,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
+        jvmTarget.set(JvmTarget.JVM_11)
         freeCompilerArgs.addAll(
             "-Xexplicit-api=strict",
             "-opt-in=kotlin.RequiresOptIn"

--- a/maps-compose/build.gradle.kts
+++ b/maps-compose/build.gradle.kts
@@ -35,8 +35,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -61,7 +61,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
+        jvmTarget.set(JvmTarget.JVM_11)
         freeCompilerArgs.addAll(
             "-Xexplicit-api=strict",
             "-opt-in=kotlin.RequiresOptIn"


### PR DESCRIPTION
Automated dependency updates for android-maps-compose rebased onto main.

### Updated Dependencies:
- `com.google.maps.android:maps-ktx`: `6.1.0` -> `6.2.0`
- `com.google.maps.android:maps-utils-ktx`: `6.1.0` -> `6.2.0`
- `com.google.maps.android:android-maps-utils`: `4.5.2` -> `5.0.0`
- `org.jetbrains.kotlin`: `2.4.0` -> `2.4.10`
- `org.jetbrains.kotlinx:kotlinx-coroutines-*`: `1.10.2` -> `1.11.0`
- `androidx.compose:compose-bom`: `2026.03.00` -> `2026.06.01`
- `androidx.core:core-ktx`: `1.18.0` -> `1.19.0`
- `io.mockk:mockk*`: `1.14.9` -> `1.14.11`
- `org.jacoco:org.jacoco.core`: `0.8.14` -> `0.8.15`

### 🛠️ JVM Target Compatibility Update
To align with `compose-bom` `2026.06.01` and `maps-ktx` `6.2.0` (which compile inline functions targeting JVM 11), `sourceCompatibility`, `targetCompatibility`, and Kotlin `jvmTarget` were upgraded to JVM 11 across modules.

### Verification
All unit tests (`testDebugUnitTest`), instrumented tests (`assembleDebugAndroidTest`), and demo sample compilation (`:maps-app:assembleDebug`) verified locally and passed cleanly against `maps-ktx:6.2.0` on Maven Central.