### PR TITLE
feat: allow GoogleMap to opt out of keyboard focus traversal

### DIFF
--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapFocusTraversalTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapFocusTraversalTests.kt
@@ -91,7 +91,6 @@ class GoogleMapFocusTraversalTests {
     fun nonFocusableMapIsSkippedDuringTabTraversal() {
         check(hasValidApiKey) { "Maps API key not specified" }
 
-        var mapLoaded = false
         composeTestRule.setContent {
             Column {
                 Button(onClick = {}, modifier = Modifier.testTag("Button1")) {
@@ -102,7 +101,6 @@ class GoogleMapFocusTraversalTests {
                         .testTag("Map")
                         .size(200.dp),
                     focusable = false,
-                    onMapLoaded = { mapLoaded = true },
                 )
                 Button(onClick = {}, modifier = Modifier.testTag("Button2")) {
                     Text("Button 2")
@@ -110,7 +108,14 @@ class GoogleMapFocusTraversalTests {
             }
         }
 
-        composeTestRule.waitUntil(timeoutMillis = 5_000) { mapLoaded }
+        // Focus traversal only requires the view hierarchy to be composed and attached,
+        // not the map tiles to have loaded.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodesWithTag("Map", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
 
         composeTestRule.onNodeWithTag("Button1").requestFocus()
         composeTestRule.onNodeWithTag("Button1").assertIsFocused()

--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapFocusTraversalTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapFocusTraversalTests.kt
@@ -16,15 +16,23 @@
 
 package com.google.maps.android.compose
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.model.LatLng
 import org.junit.Rule
 import org.junit.Test
@@ -76,5 +84,41 @@ class GoogleMapFocusTraversalTests {
         }
 
         visibleMaps[1].assertIsFocused()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun nonFocusableMapIsSkippedDuringTabTraversal() {
+        check(hasValidApiKey) { "Maps API key not specified" }
+
+        var mapLoaded = false
+        composeTestRule.setContent {
+            Column {
+                Button(onClick = {}, modifier = Modifier.testTag("Button1")) {
+                    Text("Button 1")
+                }
+                GoogleMap(
+                    modifier = Modifier
+                        .testTag("Map")
+                        .size(200.dp),
+                    focusable = false,
+                    onMapLoaded = { mapLoaded = true },
+                )
+                Button(onClick = {}, modifier = Modifier.testTag("Button2")) {
+                    Text("Button 2")
+                }
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { mapLoaded }
+
+        composeTestRule.onNodeWithTag("Button1").requestFocus()
+        composeTestRule.onNodeWithTag("Button1").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("Button1").performKeyInput {
+            pressKey(Key.Tab)
+        }
+
+        composeTestRule.onNodeWithTag("Button2").assertIsFocused()
     }
 }

--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapFocusTraversalTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapFocusTraversalTests.kt
@@ -16,11 +16,11 @@
 
 package com.google.maps.android.compose
 
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
@@ -93,18 +93,27 @@ class GoogleMapFocusTraversalTests {
 
         composeTestRule.setContent {
             Column {
-                Button(onClick = {}, modifier = Modifier.testTag("Button1")) {
-                    Text("Button 1")
-                }
+                // Plain focusable() elements are used instead of Buttons because
+                // clickable-based components only accept focus in keyboard mode,
+                // and the test starts in touch mode.
+                Box(
+                    Modifier
+                        .testTag("Item1")
+                        .size(48.dp)
+                        .focusable()
+                )
                 GoogleMap(
                     modifier = Modifier
                         .testTag("Map")
                         .size(200.dp),
                     focusable = false,
                 )
-                Button(onClick = {}, modifier = Modifier.testTag("Button2")) {
-                    Text("Button 2")
-                }
+                Box(
+                    Modifier
+                        .testTag("Item2")
+                        .size(48.dp)
+                        .focusable()
+                )
             }
         }
 
@@ -117,13 +126,13 @@ class GoogleMapFocusTraversalTests {
                 .isNotEmpty()
         }
 
-        composeTestRule.onNodeWithTag("Button1").requestFocus()
-        composeTestRule.onNodeWithTag("Button1").assertIsFocused()
+        composeTestRule.onNodeWithTag("Item1").requestFocus()
+        composeTestRule.onNodeWithTag("Item1").assertIsFocused()
 
-        composeTestRule.onNodeWithTag("Button1").performKeyInput {
+        composeTestRule.onNodeWithTag("Item1").performKeyInput {
             pressKey(Key.Tab)
         }
 
-        composeTestRule.onNodeWithTag("Button2").assertIsFocused()
+        composeTestRule.onNodeWithTag("Item2").assertIsFocused()
     }
 }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -64,6 +64,10 @@ import kotlinx.coroutines.launch
  *
  * @param modifier Modifier to be applied to the GoogleMap
  * @param mergeDescendants deactivates the map for accessibility purposes
+ * @param focusable whether the map participates in keyboard focus traversal. When true (the
+ * default), the map acts as a single focus stop so keyboard users can reach and control it. Set
+ * to false to remove the map from focus traversal entirely, e.g. when the map is used as a
+ * decorative background behind other focusable content.
  * @param cameraPositionState the [CameraPositionState] to be used to control or observe the map's
  * camera state
  * @param contentDescription the content description for the map used by accessibility services to
@@ -88,6 +92,7 @@ import kotlinx.coroutines.launch
 public fun GoogleMap(
     modifier: Modifier = Modifier,
     mergeDescendants: Boolean = false,
+    focusable: Boolean = true,
     cameraPositionState: CameraPositionState = rememberCameraPositionState(),
     contentDescription: String? = null,
     googleMapOptionsFactory: () -> GoogleMapOptions = { GoogleMapOptions() },
@@ -153,18 +158,14 @@ public fun GoogleMap(
 
         AndroidView(
             // Make the AndroidView wrapper focusable in Compose so the Compose focus
-            // system can target it during tab traversal.
-            modifier = modifier.focusable(),
+            // system can target it during tab traversal, unless the caller opted the map
+            // out of focus traversal entirely.
+            modifier = if (focusable) modifier.focusable() else modifier,
             factory = { context ->
                 val options = googleMapOptionsFactory()
                 cameraPositionState.isLiteMode = options.liteMode == true
                 mapViewFactory(context, options).also { mapView ->
-                    // Treat the MapView as a single focus stop. FOCUS_BEFORE_DESCENDANTS
-                    // ensures the map container gets focused first, and prevents the keyboard
-                    // focus from tabbing through all internal map elements (like zoom buttons
-                    // or the Google logo) by default.
-                    mapView.isFocusable = true
-                    mapView.descendantFocusability = ViewGroup.FOCUS_BEFORE_DESCENDANTS
+                    mapView.applyFocusability(focusable)
 
                     val componentCallbacks = object : ComponentCallbacks2 {
                         override fun onConfigurationChanged(newConfig: Configuration) {}
@@ -215,6 +216,7 @@ public fun GoogleMap(
                 mapView.tag = null
             },
             update = { mapView ->
+                mapView.applyFocusability(focusable)
                 if (subcompositionJob == null) {
                     subcompositionJob = parentCompositionScope.launchSubcomposition(
                         mapUpdaterState,
@@ -225,6 +227,23 @@ public fun GoogleMap(
                     )
                 }
             })
+}
+
+/**
+ * When [focusable] is true, treat the MapView as a single focus stop.
+ * FOCUS_BEFORE_DESCENDANTS ensures the map container gets focused first, and prevents the
+ * keyboard focus from tabbing through all internal map elements (like zoom buttons or the
+ * Google logo) by default.
+ * When [focusable] is false, remove the map and all of its internal elements from keyboard
+ * focus traversal altogether.
+ */
+private fun MapView.applyFocusability(focusable: Boolean) {
+    isFocusable = focusable
+    descendantFocusability = if (focusable) {
+        ViewGroup.FOCUS_BEFORE_DESCENDANTS
+    } else {
+        ViewGroup.FOCUS_BLOCK_DESCENDANTS
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes #938

## What

Adds a `focusable: Boolean = true` parameter to `GoogleMap`, providing an official way to remove the map from keyboard focus traversal, the API shape requested in #938.

## Why

#935 made the map a single keyboard focus stop by unconditionally appending `Modifier.focusable()` and forcing `mapView.isFocusable = true`. That's the right default for keyboard accessibility, but it left no way to opt out: caller-side `Modifier.focusable(false)` or `focusProperties { canFocus = false }` can't override it, since the library applies its own focus configuration after the caller's modifier and directly on the underlying `MapView`.

Apps that use the map as a decorative background behind sheets/overlays (with their own zoom/pan controls) need the map out of tab traversal entirely, otherwise keyboard focus visibly lands "behind" the overlaying content.

## How

- `focusable = true` (default): unchanged behavior from #935. The map is a single tab stop (`FOCUS_BEFORE_DESCENDANTS`).
- `focusable = false`: the Compose `.focusable()` modifier is omitted, and the `MapView` is set to `isFocusable = false` with `FOCUS_BLOCK_DESCENDANTS`, so neither the map nor its internal controls (zoom buttons, Google logo) receive keyboard focus.
- Focusability is also re-applied in `AndroidView`'s `update` block, so changing the value across recompositions takes effect on the live view.

## Testing

- Added `nonFocusableMapIsSkippedDuringTabTraversal` to `GoogleMapFocusTraversalTests`: a `focusable = false` map placed between two buttons, asserting Tab moves focus from the first button directly to the second.
- `:maps-compose:compileDebugKotlin` and `:maps-app:compileDebugAndroidTestKotlin` pass locally.

Note: the parameter is placed after `mergeDescendants` to group it with the existing accessibility-related parameter.