### PR TITLE
fix: rename InvalidatingComposeView getRotation param to avoid View shadowing

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -199,7 +199,7 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
     private fun createAndAddView(key: ViewKey<T>): ViewInfo {
         val view = InvalidatingComposeView(
             context,
-            getRotation = {
+            getRotationOverride = {
                 when (key) {
                     is ViewKey.Cluster -> clusterContentRotationState.value
                     is ViewKey.Item -> clusterItemContentRotationState.value
@@ -381,7 +381,7 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
      */
     private class InvalidatingComposeView(
         context: Context,
-        private val getRotation: () -> Float,
+        private val getRotationOverride: () -> Float,
         private val getAnchor: () -> Offset,
         private val getZIndex: () -> Float,
         private val content: @Composable () -> Unit,
@@ -392,7 +392,7 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
 
         @Composable
         override fun Content() {
-            val rotation = getRotation()
+            val rotation = getRotationOverride()
             val anchor = getAnchor()
             val zIndex = getZIndex()
             LaunchedEffect(properties.anchor, properties.zIndex, properties.rotation, rotation, anchor, zIndex) {


### PR DESCRIPTION
## Summary
- `InvalidatingComposeView` extends `AbstractComposeView` → `View`, which already declares `getRotation(): Float`. The constructor property `getRotation: () -> Float` was silently shadowed by the inherited `View` method, so calling `getRotation()` in `Content()` resolved to `View.getRotation()` instead of invoking the injected lambda.
- As a result, the `rotation` key used in the `LaunchedEffect` that triggers invalidation never reflected the actual cluster/item rotation state.
- Renamed the parameter to `getRotationOverride` to remove the ambiguity, matching how `getAnchor`/`getZIndex` are already named without collision.

Fixes #951

## Test plan
- [x] `./gradlew :maps-compose-utils:compileDebugKotlin` passes