### PR TITLE
build(ci): configure release-rc workflow to commit as googlemaps-bot

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "googlemaps-bot"
+          git config user.email "googlemaps-bot@users.noreply.github.com"
 
       - name: Update version files
         env:


### PR DESCRIPTION
Configure the Release RC workflow to author release commits and tags as `googlemaps-bot` (`googlemaps-bot@users.noreply.github.com`) instead of generic `github-actions[bot]`.

This ensures automated release candidate commits on open branches pass the Google CLA check.