### PR TITLE
fix: avoid zero-size crash in rememberComposeBitmapDescriptor when used inside Clustering

### DIFF
--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewClusteringTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewClusteringTests.kt
@@ -167,4 +167,39 @@ class GoogleMapViewClusteringTests {
             assertThat(marker.rotation).isEqualTo(180f)
         }
     }
+
+    @OptIn(MapsComposeExperimentalApi::class)
+    @Test
+    fun testClusterItemContentUsingRememberComposeBitmapDescriptorDoesNotCrash() {
+        val clusterManagerHolder = arrayOfNulls<ClusterManager<MyItem>>(1)
+        val items = listOf(MyItem(startingPosition, "Item", "Snippet", 0f))
+
+        // Regression test for https://github.com/googlemaps/android-maps-compose/issues/694:
+        // rememberComposeBitmapDescriptor used to throw "measured to have a width or height of
+        // zero" when called from content composed inside Clustering's clusterItemContent,
+        // because its parent (InvalidatingComposeView) hadn't been through an Android layout
+        // pass yet at that point.
+        val marker = initMapAndGetMarker(clusterManagerHolder) {
+            Clustering(
+                items = items,
+                clusterItemContent = {
+                    rememberComposeBitmapDescriptor {
+                        Surface(modifier = Modifier.size(20.dp)) {
+                            Text("X")
+                        }
+                    }
+                    Surface(modifier = Modifier.size(20.dp)) {
+                        Text("X")
+                    }
+                },
+                onClusterManager = { cm ->
+                    clusterManagerHolder[0] = cm
+                }
+            )
+        }
+
+        composeTestRule.runOnUiThread {
+            assertThat(marker.isVisible).isTrue()
+        }
+    }
 }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
@@ -16,6 +16,7 @@
 
 package com.google.maps.android.compose
 
+import android.graphics.Canvas
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
@@ -47,14 +48,24 @@ public fun rememberComposeBitmapDescriptor(
 }
 
 private val measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+private val fakeCanvas = Canvas()
 
 private fun renderComposableToBitmapDescriptor(
     parent: ViewGroup,
     compositionContext: CompositionContext,
     content: @Composable () -> Unit,
 ): BitmapDescriptor {
+    // Host the throwaway rendering ComposeView on the window's root view rather than on `parent`
+    // directly. `parent` (LocalView.current) can itself be mid-attach with no Android layout pass
+    // performed on it yet -- e.g. when this is called from content composed inside a Clustering
+    // item, which is first composed while its own hosting view is still being attached to its
+    // parent. `setParentCompositionContext` keeps this composition correctly scoped to the
+    // surrounding composition regardless of which Android View it's physically parented under, so
+    // it's safe to use a different, already-laid-out ViewGroup as the Android host.
+    val host = parent.rootView as? ViewGroup ?: parent
+
     val composeView =
-        ComposeView(parent.context)
+        ComposeView(host.context)
             .apply {
                 layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.WRAP_CONTENT,
@@ -63,7 +74,11 @@ private fun renderComposableToBitmapDescriptor(
                 setParentCompositionContext(compositionContext)
                 setContent(content)
             }
-            .also(parent::addView)
+            .also(host::addView)
+
+    // AndroidComposeView triggers LayoutNode's layout phase in the View draw phase, so trigger a
+    // draw to an empty canvas to force that.
+    composeView.draw(fakeCanvas)
 
     composeView.measure(measureSpec, measureSpec)
 
@@ -79,7 +94,7 @@ private fun renderComposableToBitmapDescriptor(
 
     bitmap.applyCanvas { composeView.draw(this) }
 
-    parent.removeView(composeView)
+    host.removeView(composeView)
 
     return BitmapDescriptorFactory.fromBitmap(bitmap)
 }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/RememberComposeBitmapDescriptor.kt
@@ -48,7 +48,6 @@ public fun rememberComposeBitmapDescriptor(
 }
 
 private val measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-private val fakeCanvas = Canvas()
 
 private fun renderComposableToBitmapDescriptor(
     parent: ViewGroup,
@@ -63,6 +62,7 @@ private fun renderComposableToBitmapDescriptor(
     // surrounding composition regardless of which Android View it's physically parented under, so
     // it's safe to use a different, already-laid-out ViewGroup as the Android host.
     val host = parent.rootView as? ViewGroup ?: parent
+    val canvasOfHolding = Canvas()
 
     val composeView =
         ComposeView(host.context)
@@ -76,25 +76,29 @@ private fun renderComposableToBitmapDescriptor(
             }
             .also(host::addView)
 
-    // AndroidComposeView triggers LayoutNode's layout phase in the View draw phase, so trigger a
-    // draw to an empty canvas to force that.
-    composeView.draw(fakeCanvas)
+    try {
+        // AndroidComposeView triggers LayoutNode's layout phase in the View draw phase, so trigger a
+        // draw to an empty canvas to force that.
+        composeView.draw(canvasOfHolding)
 
-    composeView.measure(measureSpec, measureSpec)
+        composeView.measure(measureSpec, measureSpec)
 
-    if (composeView.measuredWidth == 0 || composeView.measuredHeight == 0) {
-        throw IllegalStateException("The ComposeView was measured to have a width or height of " +
-                "zero. Make sure that the content has a non-zero size.")
+        if (composeView.measuredWidth == 0 || composeView.measuredHeight == 0) {
+            throw IllegalStateException(
+                "The ComposeView was measured to have a width or height of zero. " +
+                    "Make sure that the content has a non-zero size."
+            )
+        }
+
+        composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)
+
+        val bitmap =
+            createBitmap(composeView.measuredWidth, composeView.measuredHeight)
+
+        bitmap.applyCanvas { composeView.draw(this) }
+
+        return BitmapDescriptorFactory.fromBitmap(bitmap)
+    } finally {
+        host.removeView(composeView)
     }
-
-    composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)
-
-    val bitmap =
-        createBitmap(composeView.measuredWidth, composeView.measuredHeight)
-
-    bitmap.applyCanvas { composeView.draw(this) }
-
-    host.removeView(composeView)
-
-    return BitmapDescriptorFactory.fromBitmap(bitmap)
 }


### PR DESCRIPTION
## Summary
- `rememberComposeBitmapDescriptor` hosted its throwaway rendering `ComposeView` on `LocalView.current`, which can itself be mid-attach with no Android layout pass performed on it yet — this happens when the function is called from content composed inside `Clustering`'s `clusterItemContent`, since the `InvalidatingComposeView` hosting that content is still being attached to its own parent at that exact point. `measure()` returned a 0x0 size and the function threw `IllegalStateException`.
- Fix hosts the throwaway view on the window's root view instead, which is already laid out by the time any marker/cluster content is composed. `setParentCompositionContext` keeps the composition correctly scoped to the caller regardless of which Android `View` it's physically parented under, so this is safe.
- Note: this fixes `rememberComposeBitmapDescriptor` itself. Nesting the full `MarkerComposable` (not just `rememberComposeBitmapDescriptor`) inside `Clustering`'s `clusterItemContent` is a separate, unsupported combination — `MarkerComposable` also places a `Marker` node via `MapApplier`, which doesn't exist in that composition context, and will still throw `IllegalStateException: Invalid applier` regardless of this fix.

Fixes #694

## Test plan
- [x] Added `testClusterItemContentUsingRememberComposeBitmapDescriptorDoesNotCrash` to `GoogleMapViewClusteringTests`, calling `rememberComposeBitmapDescriptor` from inside `clusterItemContent` — reproduces the crash pre-fix, passes post-fix.
- [x] Ran `GoogleMapViewClusteringTests` on a physical device (Pixel 4, API 33): all 3 tests pass.
- [x] Manually reproduced the original crash on-device (`IllegalStateException: The ComposeView was measured to have a width or height of zero`) and confirmed it no longer occurs after the fix.