### PR TITLE
build: add .editorconfig for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+indent_size = 4
+max_line_length = 100
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_packages_to_use_import_on_demand = unset
+
+[*.java]
+indent_size = 4
+max_line_length = 100
+
+[*.{xml,gradle}]
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bat,cmd}]
+end_of_line = crlf
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Adds a root `.editorconfig` with basic formatting conventions (UTF-8, LF line endings, trailing whitespace trimming, final newline) and indentation rules for Kotlin, Java, Gradle, XML, YAML/JSON, and Markdown.
- Keeps formatting consistent across editors/IDEs (Android Studio, IntelliJ IDEA, etc.) and reduces formatting-only diffs in PRs.

Fixes googlemaps/android-maps-compose#964

## Test plan
- [x] Verified `.editorconfig` is picked up by Android Studio/IntelliJ (root = true, standard sections)
- N/A — config-only change, no build/test impact
