### PR TITLE
fix: guard against null in StreetView panorama change listeners

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/streetview/StreetViewPanoramaUpdater.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/streetview/StreetViewPanoramaUpdater.kt
@@ -39,11 +39,13 @@ internal class StreetViewPanoramaPropertiesNode(
         panorama.setOnStreetViewPanoramaLongClickListener {
             eventListeners.onLongClick(it)
         }
+        // Both Java listener interfaces lack @NonNull, so GMS can deliver null. Guard the
+        // assignments to prevent the Kotlin compiler's implicit null-check from crashing.
         panorama.setOnStreetViewPanoramaCameraChangeListener {
-            cameraPositionState.rawPanoramaCamera = it
+            it?.let { cameraPositionState.rawPanoramaCamera = it }
         }
         panorama.setOnStreetViewPanoramaChangeListener {
-            cameraPositionState.rawLocation = it
+            it?.let { cameraPositionState.rawLocation = it }
         }
     }
 


### PR DESCRIPTION
## Description

The `OnStreetViewPanoramaChangeListener` and `OnStreetViewPanoramaCameraChangeListener` Java interfaces in `play-services-maps` do not annotate their callback parameters as `@NonNull`. The GMS dynamite module (`policy_maps_core_dynamite`) can deliver `null` to these listeners on certain devices and Play Services versions.

In `StreetViewPanoramaPropertiesNode.onAttached()`, both lambdas assigned the callback value directly to non-nullable Kotlin state fields (`rawLocation` and `rawPanoramaCamera`). The Kotlin compiler inserts an implicit null-check intrinsic at lambda entry — before the assignment — which throws a `NullPointerException` when `null` arrives, crashing the app.

### Crash trace

```
Fatal Exception: com.google.maps.api.android.lib6.common.apiexception.f: NullPointerException:
  Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at com.google.maps.android.compose.streetview.StreetViewPanoramaPropertiesNode.onAttached$lambda$3
```

Lambda index 3 in `onAttached()` is the `setOnStreetViewPanoramaChangeListener` callback. The `getClass()` call is the Kotlin-generated null check, not application code.

### Changes

Guard both listener assignments with a null-safe `let` block in `StreetViewPanoramaUpdater.kt`:

```kotlin
// before
panorama.setOnStreetViewPanoramaChangeListener {
    cameraPositionState.rawLocation = it
}

// after
panorama.setOnStreetViewPanoramaChangeListener {
    it?.let { cameraPositionState.rawLocation = it }
}
```

The same pattern is applied to `setOnStreetViewPanoramaCameraChangeListener` for consistency, as `StreetViewPanoramaCamera` is also non-nullable in `rawPanoramaCamera` but the Java interface carries no `@NonNull` guarantee.

### Testing

The fix is purely defensive against a null delivery from the GMS layer, which cannot be injected in an instrumented test. The existing `StreetViewTests` continue to exercise the normal flow unchanged.

---

Re-submission of #904, which was closed when the original fork was deleted. Same commit (`89b4b1f`, author unchanged, Google CLA signed as an individual), cherry-picked onto current `main` — the diff is identical.
