### PR TITLE
fix: pin ViewTreeLifecycleOwner/SavedStateRegistryOwner on MapView to prevent info window crash

### DIFF
--- a/maps-compose/src/main/java/com/google/maps/android/compose/ComposeInfoWindowAdapter.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/ComposeInfoWindowAdapter.kt
@@ -57,8 +57,9 @@ internal class ComposeInfoWindowAdapter(
     private fun renderToImageView(
         markerNode: MarkerNode,
         content: @Composable () -> Unit,
-    ): View {
+    ): View? {
         val bitmap = mapView.renderComposableToBitmap(markerNode.compositionContext, content)
+            ?: return null
         return ImageView(mapView.context).apply {
             layoutParams = ViewGroup.LayoutParams(bitmap.width, bitmap.height)
             scaleType = ImageView.ScaleType.FIT_XY

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -43,7 +43,11 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.LocationSource
 import com.google.android.gms.maps.MapView
@@ -117,6 +121,15 @@ public fun GoogleMap(
         return
     }
 
+    // The Maps SDK measures Compose info-window content from its own Handler, asynchronously.
+    // If that measure lands after Compose has unparented the MapView (e.g. on LazyColumn
+    // recycling), the info window's ComposeView can no longer resolve a ViewTreeLifecycleOwner
+    // via its ancestors, since that tag lives on this AndroidView's holder rather than on the
+    // MapView itself. Pinning the owners directly onto the MapView keeps them resolvable from
+    // its own subtree regardless of where Compose has parented it.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+
     // rememberUpdatedState and friends are used here to make these values observable to
     // the subcomposition without providing a new content function each recomposition
     val mapClickListeners = remember { MapClickListeners() }.also {
@@ -175,6 +188,8 @@ public fun GoogleMap(
                 cameraPositionState.isLiteMode = options.liteMode == true
                 mapViewFactory(context, options).also { mapView ->
                     mapView.applyFocusability(focusable)
+                    mapView.setViewTreeLifecycleOwner(lifecycleOwner)
+                    mapView.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
 
                     val componentCallbacks = object : ComponentCallbacks2 {
                         override fun onConfigurationChanged(newConfig: Configuration) {}
@@ -226,6 +241,8 @@ public fun GoogleMap(
             },
             update = { mapView ->
                 mapView.applyFocusability(focusable)
+                mapView.setViewTreeLifecycleOwner(lifecycleOwner)
+                mapView.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
                 if (subcompositionJob == null) {
                     subcompositionJob = parentCompositionScope.launchSubcomposition(
                         mapUpdaterState,

--- a/maps-compose/src/main/java/com/google/maps/android/compose/MapComposeViewRender.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/MapComposeViewRender.kt
@@ -63,11 +63,18 @@ private val unspecifiedMeasureSpec =
  * [com.google.android.gms.maps.GoogleMap.InfoWindowAdapter]) that take ownership of the view they
  * receive and re-parent it into their own hierarchy — which would otherwise crash with
  * "The specified child already has a parent" if handed a view still attached elsewhere.
+ *
+ * Returns `null` if this [MapView] is no longer attached to a window by the time [content] is
+ * measured. That happens when the Maps SDK's own async render request (which drives this call)
+ * lands after Compose has already unparented the [MapView] (e.g. `LazyColumn` recycling/detach):
+ * the composition never gets a real layout pass, so it measures to zero size. There's no info
+ * window worth rendering for a map that's already being torn down, so this is treated as "nothing
+ * to show" rather than an error.
  */
 internal fun MapView.renderComposableToBitmap(
     parentContext: CompositionContext,
     content: @Composable () -> Unit,
-): Bitmap {
+): Bitmap? {
     val containerView = ensureContainerView()
     val composeView = ComposeView(context).apply {
         layoutParams = ViewGroup.LayoutParams(
@@ -80,13 +87,21 @@ internal fun MapView.renderComposableToBitmap(
     containerView.addView(composeView)
 
     composeView.measure(unspecifiedMeasureSpec, unspecifiedMeasureSpec)
-    check(composeView.measuredWidth > 0 && composeView.measuredHeight > 0) {
-        "The info window content was measured to have a width or height of zero. " +
-            "Make sure that the content has a non-zero size."
-    }
-    composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)
+    val width = composeView.measuredWidth
+    val height = composeView.measuredHeight
 
-    val bitmap = createBitmap(composeView.measuredWidth, composeView.measuredHeight)
+    if (width <= 0 || height <= 0) {
+        containerView.removeView(composeView)
+        check(!isAttachedToWindow) {
+            "The info window content was measured to have a width or height of zero. " +
+                "Make sure that the content has a non-zero size."
+        }
+        return null
+    }
+
+    composeView.layout(0, 0, width, height)
+
+    val bitmap = createBitmap(width, height)
     bitmap.applyCanvas { composeView.draw(this) }
 
     containerView.removeView(composeView)


### PR DESCRIPTION
## Summary

Fixes #971.

On compose-ui 1.11+, `MarkerInfoWindow` / `MarkerInfoWindowContent` can crash with:

```
java.lang.IllegalStateException: Composed into the View which doesn't propagate ViewTreeLifecycleOwner!
```

The Maps SDK measures the info-window `ComposeView` from its own `Handler`, asynchronously. If that measure lands after Compose has unparented the `MapView` (e.g. `LazyColumn` recycling/detach), the `ComposeView` can no longer resolve a `ViewTreeLifecycleOwner`/`ViewTreeSavedStateRegistryOwner` by walking up its ancestors, because those tags live on the `AndroidView` holder — the `MapView`'s *parent* — not on the `MapView` itself. `AbstractComposeView.onMeasure` then throws (this became fatal in compose-ui 1.11, which moved owner resolution into `onMeasure`; on 1.10 it silently rendered blank instead).

## Fix

Two commits:

1. **Pin the ViewTree owners onto the `MapView`** (`GoogleMap.kt`) — at creation in the `AndroidView` factory, and on every `update` in case the owner identity changes. This keeps the owner lookup resolvable from within the map's own subtree regardless of where Compose has parented the `MapView`, without changing behavior while attached (same owner instances `AndroidView` already assigns to the parent).

2. **Handle the now-reachable zero-size render gracefully** (`MapComposeViewRender.kt`, `ComposeInfoWindowAdapter.kt`) — with (1) alone, the original crash is gone, but on this codebase's bitmap-based info-window rendering (#953) the same detached-render race surfaces a *second* crash: `renderComposableToBitmap`'s own `check()` rejects the zero-size measurement that naturally results from compositing a `ComposeView` that never got a real window attachment. A `MapView` mid-teardown has nothing worth rendering anyway, so that specific case (zero-size **and** not attached to window) now returns `null` instead of throwing, propagated through the already-nullable `getInfoContents()`/`getInfoWindow()`. Zero-size content on an *attached* `MapView` still throws with the original message — that's a genuine content-authoring bug, not a teardown race.

## Test plan

- [x] `./gradlew :maps-compose:compileDebugKotlin` — builds clean
- [x] `./gradlew :maps-compose:lintDebug` — no new issues
- [x] **Verified on a physical device** (Pixel 4, Android 13, GMS 26.32.62, phoenix renderer) using the exact `LazyColumn`-recycling repro from #971 (`showInfoWindow()` + scroll-out in the same beat, repeated in a loop):
  - **Baseline (no fix)**: crashes with the exact reported `ViewTreeLifecycleOwner` `IllegalStateException`, stack trace matching #971 line-for-line, within the first ~20 cycles.
  - **Fix 1 only**: original crash gone, but a *different* crash appears (`renderComposableToBitmap`'s zero-size `check()`) — this codebase's info-window rendering had already been rewritten to a bitmap-based approach (#953) since 8.4.0, exposing this second issue.
  - **Both fixes applied**: 420+ cycles over 60s, no crash, process alive throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)