### PR TITLE
fix(maps-compose): apply mapColorScheme to GoogleMapOptions during MapView creation

### DIFF
--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -27,8 +27,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MapColorScheme
 import com.google.common.truth.Truth.assertThat
 import com.google.maps.android.compose.LatLngSubject.Companion.assertThat
 import kotlinx.coroutines.runBlocking
@@ -88,15 +91,51 @@ class GoogleMapViewTests {
 
     @Test
     fun testRightInitialColorScheme() {
-        initMap()
-        assertThat(mapColorScheme).isEqualTo(ComposeMapColorScheme.FOLLOW_SYSTEM)
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM,
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.FOLLOW_SYSTEM)
     }
 
     @Test
     fun testRightColorSchemeAfterChangingIt() {
-        mapColorScheme = ComposeMapColorScheme.DARK
-        initMap()
-        assertThat(mapColorScheme).isEqualTo(ComposeMapColorScheme.DARK)
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                mapColorScheme = ComposeMapColorScheme.DARK,
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.DARK)
+    }
+
+    @Test
+    fun testColorSchemeInOptionsNotOverwritten() {
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                googleMapOptionsFactory = {
+                    GoogleMapOptions().mapColorScheme(MapColorScheme.DARK)
+                },
+                mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM,
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        // When googleMapOptionsFactory explicitly sets a color scheme (e.g. DARK), it should not be overwritten by mapColorScheme
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.DARK)
     }
 
     @Test

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -162,7 +162,16 @@ public fun GoogleMap(
             // out of focus traversal entirely.
             modifier = if (focusable) modifier.focusable() else modifier,
             factory = { context ->
-                val options = googleMapOptionsFactory()
+                val options = googleMapOptionsFactory().let { opts ->
+                    // If mapColorScheme is passed to GoogleMap() and has not been explicitly set
+                    // in googleMapOptionsFactory (where 0 / MapColorScheme.LIGHT is the Java int default),
+                    // apply it to GoogleMapOptions so MapView is created with it.
+                    if (mapColorScheme != null && opts.mapColorScheme == 0) {
+                        opts.mapColorScheme(mapColorScheme.value)
+                    } else {
+                        opts
+                    }
+                }
                 cameraPositionState.isLiteMode = options.liteMode == true
                 mapViewFactory(context, options).also { mapView ->
                     mapView.applyFocusability(focusable)


### PR DESCRIPTION
GoogleMap() currently applies mapColorScheme via map.setMapColorScheme() only after getMapAsync() completes. However, the Maps SDK's terrain renderer only respects FOLLOW_SYSTEM/DARK when it is present in GoogleMapOptions at MapView creation time; calling setMapColorScheme() later on an already-initialized terrain map with custom MapStyleOptions fails to trigger dark terrain shaders.

This change updates AndroidView's factory in GoogleMap.kt to automatically populate GoogleMapOptions.mapColorScheme from the mapColorScheme parameter if it has not been explicitly configured in googleMapOptionsFactory.

Also fixes GoogleMapViewTests.kt to replace vacuous tests (which asserted against a test-local variable) with real assertions against the GoogleMapOptions passed to mapViewFactory, and adds a test verifying that an explicitly configured googleMapOptionsFactory is not overwritten.

Verified via ./gradlew :maps-compose:compileDebugKotlin and test suite.