### PR TITLE
chore(maps-compose-utils): remove unused Bitmap import in ClusterRenderer.kt

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshotFlow
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.view.View
 import android.view.ViewGroup


### PR DESCRIPTION
## Summary
Resolves a `KotlincWarningsUNUSED_IMPORT` warning reported in Critique CL 968695609 for `android-maps-compose`.

---

## Detailed Changes
- **`ClusterRenderer.kt`** (`maps-compose-utils` module):
  - `KotlincWarningsUNUSED_IMPORT`: Removed unused `import android.graphics.Bitmap` on line 26.

---

## Verification
- **Gradle Build**: `./gradlew :maps-compose-utils:compileDebugKotlin` — **BUILD SUCCESSFUL**