### PR TITLE
ci: avoid flaky wait on transient isMoving in non-animated zoom tests

### DIFF
--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -40,6 +40,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 
 class GoogleMapViewTests {
     @get:Rule
@@ -183,13 +184,24 @@ class GoogleMapViewTests {
     fun testCameraZoomIn() {
         initMap()
         zoom(shouldAnimate = false, zoomIn = true) {
-            // moveCamera() is synchronous, so onCameraMoveStarted/onCameraIdle can both
-            // fire before Compose observes the intermediate `isMoving = true` state.
-            // Only wait for the move to have settled before checking the result.
+            val expectedZoom = startingZoom + 1f
+            // Non-animated camera updates (CameraPositionState.move) execute synchronously via
+            // GoogleMap.moveCamera(). The Maps SDK fires OnCameraMoveStartedListener (setting
+            // isMoving = true) and OnCameraIdleListener (setting isMoving = false) in rapid succession.
+            //
+            // Because Compose test polling samples state across frames, polling for the transient
+            // `isMoving = true` state is flaky. Instead:
+            // 1. We first wait until the zoom transition has actually occurred.
+            // 2. We then wait for the camera to settle completely (!isMoving).
+            composeTestRule.waitUntil(timeout3) {
+                abs(cameraPositionState.position.zoom - expectedZoom) <= assertRoundingError
+            }
+            assertThat(cameraPositionState.position.zoom).isWithin(assertRoundingError.toFloat()).of(expectedZoom)
+
             composeTestRule.waitUntil(timeout3) {
                 !cameraPositionState.isMoving
             }
-            assertThat(cameraPositionState.position.zoom).isWithin(assertRoundingError.toFloat()).of(startingZoom + 1f)
+            assertThat(cameraPositionState.isMoving).isFalse()
         }
     }
 
@@ -197,13 +209,24 @@ class GoogleMapViewTests {
     fun testCameraZoomOut() {
         initMap()
         zoom(shouldAnimate = false, zoomIn = false) {
-            // moveCamera() is synchronous, so onCameraMoveStarted/onCameraIdle can both
-            // fire before Compose observes the intermediate `isMoving = true` state.
-            // Only wait for the move to have settled before checking the result.
+            val expectedZoom = startingZoom - 1f
+            // Non-animated camera updates (CameraPositionState.move) execute synchronously via
+            // GoogleMap.moveCamera(). The Maps SDK fires OnCameraMoveStartedListener (setting
+            // isMoving = true) and OnCameraIdleListener (setting isMoving = false) in rapid succession.
+            //
+            // Because Compose test polling samples state across frames, polling for the transient
+            // `isMoving = true` state is flaky. Instead:
+            // 1. We first wait until the zoom transition has actually occurred.
+            // 2. We then wait for the camera to settle completely (!isMoving).
+            composeTestRule.waitUntil(timeout3) {
+                abs(cameraPositionState.position.zoom - expectedZoom) <= assertRoundingError
+            }
+            assertThat(cameraPositionState.position.zoom).isWithin(assertRoundingError.toFloat()).of(expectedZoom)
+
             composeTestRule.waitUntil(timeout3) {
                 !cameraPositionState.isMoving
             }
-            assertThat(cameraPositionState.position.zoom).isWithin(assertRoundingError.toFloat()).of(startingZoom - 1f)
+            assertThat(cameraPositionState.isMoving).isFalse()
         }
     }
 

--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -183,9 +183,9 @@ class GoogleMapViewTests {
     fun testCameraZoomIn() {
         initMap()
         zoom(shouldAnimate = false, zoomIn = true) {
-            composeTestRule.waitUntil(timeout2) {
-                cameraPositionState.isMoving
-            }
+            // moveCamera() is synchronous, so onCameraMoveStarted/onCameraIdle can both
+            // fire before Compose observes the intermediate `isMoving = true` state.
+            // Only wait for the move to have settled before checking the result.
             composeTestRule.waitUntil(timeout3) {
                 !cameraPositionState.isMoving
             }
@@ -197,9 +197,9 @@ class GoogleMapViewTests {
     fun testCameraZoomOut() {
         initMap()
         zoom(shouldAnimate = false, zoomIn = false) {
-            composeTestRule.waitUntil(timeout2) {
-                cameraPositionState.isMoving
-            }
+            // moveCamera() is synchronous, so onCameraMoveStarted/onCameraIdle can both
+            // fire before Compose observes the intermediate `isMoving = true` state.
+            // Only wait for the move to have settled before checking the result.
             composeTestRule.waitUntil(timeout3) {
                 !cameraPositionState.isMoving
             }


### PR DESCRIPTION
## Summary
- `testCameraZoomIn` / `testCameraZoomOut` were intermittently failing with `ComposeTimeoutException: Condition still not satisfied after 2000 ms` while waiting for `cameraPositionState.isMoving` to become `true`.
- Root cause: for non-animated zoom (`map.moveCamera()`), the SDK fires `onCameraMoveStarted` and `onCameraIdle`/`onCameraMoveCanceled` synchronously back-to-back (see `MapUpdater.kt`), so `isMoving` can flip `true` → `false` before Compose's `waitUntil` polling ever observes the intermediate `true` state. This isn't infra flakiness, it's a race baked into the assertion order — the animated variants aren't affected because the animation genuinely holds `isMoving = true` for ~300ms.
- Removed the unobservable `waitUntil(timeout2) { isMoving }` step from the two non-animated tests; they now just wait for the move to settle (`!isMoving`) before asserting the final zoom value.

## Test plan
- [x] Ran `testCameraZoomIn`, `testCameraZoomOut`, `testCameraZoomInAnimation`, `testCameraZoomOutAnimation` on a connected emulator (Pixel 7, API 17) via `./gradlew :maps-app:connectedDebugAndroidTest`, all 4 passed.