### PR TITLE
feat(clustering,maps-compose): remove deprecated rememberSaveable key and optimize loops

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/clustering/ClusterRenderer.kt
@@ -124,7 +124,7 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
                     clusterItemContentZIndexState.value,
                 )
             }.collect {
-                keysToViews.forEach { (key, viewInfo) ->
+                for ((key, viewInfo) in keysToViews) {
                     when (key) {
                         is ViewKey.Cluster -> {
                             getMarker(key.cluster)?.apply {
@@ -158,15 +158,15 @@ internal class ComposeUiClusterRenderer<T : ClusterItem>(
 
         val keys = clusters.flatMap { it.computeViewKeys() }
 
-        with(keysToViews.iterator()) {
-            forEach { (key, viewInfo) ->
-                if (key !in keys) {
-                    remove()
-                    viewInfo.onRemove()
-                }
+        val iterator = keysToViews.iterator()
+        while (iterator.hasNext()) {
+            val (key, viewInfo) = iterator.next()
+            if (key !in keys) {
+                iterator.remove()
+                viewInfo.onRemove()
             }
         }
-        keys.forEach { key ->
+        for (key in keys) {
             if (key !in keysToViews.keys) {
                 createAndAddView(key)
             }

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraMoveStartedReason.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraMoveStartedReason.kt
@@ -14,8 +14,6 @@
 package com.google.maps.android.compose
 
 import androidx.compose.runtime.Immutable
-import com.google.maps.android.compose.CameraMoveStartedReason.Companion.fromInt
-import com.google.maps.android.compose.CameraMoveStartedReason.NO_MOVEMENT_YET
 import com.google.maps.android.compose.CameraMoveStartedReason.UNKNOWN
 
 /**

--- a/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/CameraPositionState.kt
@@ -72,7 +72,7 @@ public inline fun rememberCameraPositionState(
 public inline fun rememberCameraPositionState(
     key: String? = null,
     crossinline init: CameraPositionState.() -> Unit = {}
-): CameraPositionState = rememberSaveable(key = key, saver = CameraPositionState.Saver) {
+): CameraPositionState = rememberSaveable(saver = CameraPositionState.Saver) {
     CameraPositionState().apply(init)
 }
 

--- a/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/Marker.kt
@@ -195,7 +195,7 @@ public class MarkerState private constructor(position: LatLng) {
             "so it will be changed or removed.",
     replaceWith = ReplaceWith(
         expression = """
-            val markerState = rememberSaveable(key = key, saver = MarkerState.Saver) {
+            val markerState = rememberSaveable(saver = MarkerState.Saver) {
                 MarkerState(position)
             }
         """
@@ -204,7 +204,7 @@ public class MarkerState private constructor(position: LatLng) {
 public fun rememberMarkerState(
     key: String? = null,
     position: LatLng = LatLng(0.0, 0.0)
-): MarkerState = rememberSaveable(key = key, saver = MarkerState.Saver) {
+): MarkerState = rememberSaveable(saver = MarkerState.Saver) {
     MarkerState(position)
 }
 


### PR DESCRIPTION
### Summary

Applies upstream lint fixes, Compose deprecation removals, and loop optimizations:

### Changes
1. **Removed unused imports** (`fromInt`, `NO_MOVEMENT_YET`) in `CameraMoveStartedReason.kt`.
2. **Removed deprecated `key` parameter** from `rememberSaveable` invocations in `CameraPositionState.kt` and `Marker.kt`.
3. **Replaced `.forEach` with standard `for` loops** and while-iterator pattern in `ClusterRenderer.kt`.

### Reviewer
cc @LoyalAbbas
