### PR TITLE
feat(maps-compose): default mapColorScheme to FOLLOW_SYSTEM in GoogleMap

### DIFF
--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -91,6 +91,35 @@ class GoogleMapViewTests {
     }
 
     @Test
+    fun testDefaultColorSchemeIsFollowSystem() {
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.FOLLOW_SYSTEM)
+    }
+
+    @Test
+    fun testDefaultColorSchemeWithGoogleMapOptionsFactory() {
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                googleMapOptionsFactory = { GoogleMapOptions().liteMode(false) },
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.FOLLOW_SYSTEM)
+    }
+
+    @Test
     fun testRightInitialColorScheme() {
         var capturedOptions: GoogleMapOptions? = null
         composeTestRule.setContent {

--- a/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
+++ b/maps-compose/src/main/java/com/google/maps/android/compose/GoogleMap.kt
@@ -89,7 +89,7 @@ import kotlinx.coroutines.launch
  * @param onPOIClick lambda invoked when a POI is clicked
  * @param contentPadding the padding values used to signal that portions of the map around the edges
  * may be obscured. The map will move the Google logo, etc. to avoid overlapping the padding.
- * @param mapColorScheme Defines the color scheme for the Map.
+ * @param mapColorScheme Defines the color scheme for the Map. Defaults to [ComposeMapColorScheme.FOLLOW_SYSTEM].
  * @param content the content of the map
  */
 @Composable
@@ -111,7 +111,7 @@ public fun GoogleMap(
     onMyLocationClick: ((Location) -> Unit)? = null,
     onPOIClick: ((PointOfInterest) -> Unit)? = null,
     contentPadding: PaddingValues = DefaultMapContentPadding,
-    mapColorScheme: ComposeMapColorScheme? = null,
+    mapColorScheme: ComposeMapColorScheme? = ComposeMapColorScheme.FOLLOW_SYSTEM,
     mapViewFactory: (Context, GoogleMapOptions) -> MapView = ::MapView,
     content: @Composable @GoogleMapComposable () -> Unit = {},
 ) {


### PR DESCRIPTION
## Description
This PR updates `GoogleMap`'s `mapColorScheme` parameter to default to `ComposeMapColorScheme.FOLLOW_SYSTEM` instead of `null`.

### Rationale
* Previously, `mapColorScheme` defaulted to `null`. As `GoogleMapOptions.getMapColorScheme()` returns Java's default `0` (`MapColorScheme.LIGHT`) and `MapUpdater` skipped setting `map.mapColorScheme` when `mapColorScheme` was null, maps initialized without an explicit `mapColorScheme` parameter were silently forced into light mode, even when the host device was in system dark theme.
* Defaulting to `ComposeMapColorScheme.FOLLOW_SYSTEM` ensures `GoogleMap` automatically adapts to the system theme out of the box, adhering to standard Jetpack Compose and Material 3 design expectations.

### Verification
* Added regression tests `testDefaultColorSchemeIsFollowSystem` and `testDefaultColorSchemeWithGoogleMapOptionsFactory` in `GoogleMapViewTests.kt`.
* Verified all 22 tests in `GoogleMapViewTests` pass on device.