### PR TITLE
sample(maps-app): follow system theme in LiteModeActivity and add documentation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ To run the demo app, ensure you've met the requirements above then:
 
 See the [documentation] for a full list of classes and their methods.
 
+### Guides
+* [Supporting Dark Theme in Lite Mode Maps](docs/lite-mode-dark-theme.md)
+
 ## Usage
 
 Adding a map to your app looks like the following:

--- a/docs/lite-mode-dark-theme.md
+++ b/docs/lite-mode-dark-theme.md
@@ -1,0 +1,166 @@
+# Supporting Dark Theme in Lite Mode Maps
+
+This guide explains how to make a Lite Mode map in [Maps Compose](https://github.com/googlemaps/android-maps-compose) follow the Android system theme and switch to a dark palette automatically.
+
+---
+
+## Overview
+
+In standard (interactive) mode, Maps Compose supports dark mode directly via the `mapColorScheme` parameter:
+
+```kotlin
+GoogleMap(
+    mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM
+)
+```
+
+However, when Lite Mode is enabled (`GoogleMapOptions().liteMode(true)`), the underlying Google Maps Android SDK (`play-services-maps`) functions differently:
+
+1. **Static Pre-rendered Tiles**: Lite Mode maps fetch static raster tiles rather than rendering vectors on the client GPU.
+2. **`MapColorScheme` Bypassed**: The Google Maps Android SDK explicitly ignores dynamic `MapColorScheme` configurations for Lite Mode maps.
+3. **Map Types Remain in Light Mode**: Neither `MapType.NORMAL` nor `MapType.TERRAIN` will render dark tiles through `mapColorScheme`.
+
+To support dark mode on a Lite Mode map, your application must listen for system theme changes and dynamically supply a custom dark JSON style using `MapProperties.mapStyleOptions`.
+
+---
+
+## Implementation Steps
+
+### 1. Define a Dark Map Style JSON
+
+Lite Mode maps support styling through standard Google Maps JSON style definitions. Define a compact dark palette constant (or store it in `res/raw/map_style_dark.json`):
+
+```kotlin
+private const val DARK_STYLE_JSON = """[
+  {"elementType": "geometry", "stylers": [{"color": "#242f3e"}]},
+  {"elementType": "labels.text.stroke", "stylers": [{"color": "#242f3e"}]},
+  {"elementType": "labels.text.fill", "stylers": [{"color": "#746855"}]},
+  {"featureType": "administrative.locality", "elementType": "labels.text.fill", "stylers": [{"color": "#d59563"}]},
+  {"featureType": "poi", "elementType": "labels.text.fill", "stylers": [{"color": "#d59563"}]},
+  {"featureType": "poi.park", "elementType": "geometry", "stylers": [{"color": "#263c3f"}]},
+  {"featureType": "poi.park", "elementType": "labels.text.fill", "stylers": [{"color": "#6b9a76"}]},
+  {"featureType": "road", "elementType": "geometry", "stylers": [{"color": "#38414e"}]},
+  {"featureType": "road", "elementType": "geometry.stroke", "stylers": [{"color": "#212a37"}]},
+  {"featureType": "road", "elementType": "labels.text.fill", "stylers": [{"color": "#9ca5b3"}]},
+  {"featureType": "road.highway", "elementType": "geometry", "stylers": [{"color": "#746855"}]},
+  {"featureType": "water", "elementType": "geometry", "stylers": [{"color": "#17263c"}]},
+  {"featureType": "water", "elementType": "labels.text.fill", "stylers": [{"color": "#515c6d"}]}
+]"""
+```
+
+### 2. Observe the System Setting in Compose
+
+In Jetpack Compose, `isSystemInDarkTheme()` observes `LocalConfiguration.current` and automatically triggers recomposition whenever the user changes the system theme or when an automated schedule activates.
+
+```kotlin
+val isSystemDark = isSystemInDarkTheme()
+```
+
+### 3. Dynamically Apply `MapStyleOptions`
+
+Construct a `MapProperties` instance that applies `MapStyleOptions` conditionally based on the active dark theme state:
+
+```kotlin
+val mapProperties = remember(isSystemDark) {
+    MapProperties(
+        mapType = MapType.NORMAL,
+        mapStyleOptions = if (isSystemDark) MapStyleOptions(DARK_STYLE_JSON) else null
+    )
+}
+```
+
+### 4. Provide Lite Mode Options
+
+Create the `GoogleMap` composable passing `GoogleMapOptions().liteMode(true)` via `googleMapOptionsFactory`:
+
+```kotlin
+GoogleMap(
+    modifier = Modifier.fillMaxSize(),
+    googleMapOptionsFactory = {
+        GoogleMapOptions().liteMode(true)
+    },
+    properties = mapProperties,
+)
+```
+
+---
+
+## Full Working Example
+
+Below is a complete, self-contained composable showing how to combine system theme observation with user overrides (`System`, `Light`, `Dark`):
+
+```kotlin
+enum class ThemeOption {
+    SYSTEM,
+    LIGHT,
+    DARK
+}
+
+@Composable
+fun ThemedLiteMapScreen() {
+    var selectedTheme by rememberSaveable { mutableStateOf(ThemeOption.SYSTEM) }
+    val systemInDarkTheme = isSystemInDarkTheme()
+
+    val isDark = when (selectedTheme) {
+        ThemeOption.SYSTEM -> systemInDarkTheme
+        ThemeOption.LIGHT -> false
+        ThemeOption.DARK -> true
+    }
+
+    val mapProperties = remember(isDark) {
+        MapProperties(
+            mapType = MapType.NORMAL,
+            mapStyleOptions = if (isDark) MapStyleOptions(DARK_STYLE_JSON) else null
+        )
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Theme selector
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilterChip(
+                selected = selectedTheme == ThemeOption.SYSTEM,
+                onClick = { selectedTheme = ThemeOption.SYSTEM },
+                label = { Text("System") }
+            )
+            FilterChip(
+                selected = selectedTheme == ThemeOption.LIGHT,
+                onClick = { selectedTheme = ThemeOption.LIGHT },
+                label = { Text("Light") }
+            )
+            FilterChip(
+                selected = selectedTheme == ThemeOption.DARK,
+                onClick = { selectedTheme = ThemeOption.DARK },
+                label = { Text("Dark") }
+            )
+        }
+
+        // Lite Mode Map
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            GoogleMap(
+                modifier = Modifier.fillMaxSize(),
+                googleMapOptionsFactory = { GoogleMapOptions().liteMode(true) },
+                properties = mapProperties,
+            )
+        }
+    }
+}
+```
+
+---
+
+## Best Practices
+
+* **Memoize Properties**: Wrap `MapProperties` creation in `remember(isDark, mapType)` to avoid allocating new style options on unrelated recompositions.
+* **Preserve State Across Recreations**: Use `rememberSaveable` for any user-selected theme or map settings so selections persist when the device configuration changes.
+* **Camera Movement**: In Lite Mode, `cameraPositionState.animate(...)` completes immediately without continuous panning animations.
+* **Interactive Mode Alternative**: If native vector dark terrain shaders or full gesture interactions are needed, use interactive mode (`liteMode(false)`) with `mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM`.
+
+---
+
+## Sample Code
+
+A complete, runnable demonstration of this pattern is available in the sample application:
+* [LiteModeActivity.kt](../maps-app/src/main/java/com/google/maps/android/compose/LiteModeActivity.kt)

--- a/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
+++ b/maps-app/src/androidTest/java/com/google/maps/android/compose/GoogleMapViewTests.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.model.CameraPosition
@@ -166,6 +167,61 @@ class GoogleMapViewTests {
         }
         // When googleMapOptionsFactory explicitly sets a color scheme (e.g. DARK), it should not be overwritten by mapColorScheme
         assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.DARK)
+    }
+
+    @Test
+    fun testLiteModePreservesColorSchemeAndLiteModeInOptions() {
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                googleMapOptionsFactory = { GoogleMapOptions().liteMode(true) },
+                mapColorScheme = ComposeMapColorScheme.DARK,
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.liteMode).isTrue()
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.DARK)
+    }
+
+    @Test
+    fun testLiteModeWithTerrainMapTypePreservesOptions() {
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                googleMapOptionsFactory = {
+                    GoogleMapOptions()
+                        .liteMode(true)
+                        .mapType(GoogleMap.MAP_TYPE_TERRAIN)
+                },
+                mapColorScheme = ComposeMapColorScheme.DARK,
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.liteMode).isTrue()
+        assertThat(capturedOptions?.mapType).isEqualTo(GoogleMap.MAP_TYPE_TERRAIN)
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.DARK)
+    }
+
+    @Test
+    fun testLiteModeDefaultColorSchemeIsFollowSystem() {
+        var capturedOptions: GoogleMapOptions? = null
+        composeTestRule.setContent {
+            GoogleMap(
+                googleMapOptionsFactory = { GoogleMapOptions().liteMode(true) },
+                mapViewFactory = { context, options ->
+                    capturedOptions = options
+                    MapView(context, options)
+                }
+            )
+        }
+        assertThat(capturedOptions?.liteMode).isTrue()
+        assertThat(capturedOptions?.mapColorScheme).isEqualTo(MapColorScheme.FOLLOW_SYSTEM)
     }
 
     @Test

--- a/maps-app/src/main/java/com/google/maps/android/compose/LiteModeActivity.kt
+++ b/maps-app/src/main/java/com/google/maps/android/compose/LiteModeActivity.kt
@@ -20,76 +20,217 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.maps.android.compose.theme.MapsComposeSampleTheme
 import kotlinx.coroutines.launch
 
+/**
+ * Theme selection options for the sample.
+ */
+enum class ThemeOption {
+    SYSTEM,
+    LIGHT,
+    DARK
+}
+
+/**
+ * Demonstrates GoogleMap in Lite Mode following the system theme setting, camera movements,
+ * and custom map styling.
+ *
+ * ### Following System Theme in Lite Mode:
+ * The underlying Google Maps Android SDK serves static pre-rendered tiles in Lite Mode and does
+ * not support dynamic [com.google.android.gms.maps.model.MapColorScheme].
+ *
+ * To have a Lite Mode map follow the system setting:
+ * 1. Listen for system theme changes using [isSystemInDarkTheme].
+ * 2. Dynamically apply a custom dark JSON style via [MapProperties.mapStyleOptions] when dark theme is active.
+ *
+ * For a complete guide on this technique, see [Lite Mode Dark Theme Guide](../../../../../../../../../docs/lite-mode-dark-theme.md).
+ */
 class LiteModeActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            MapsComposeSampleTheme {
-                val singapore = remember { LatLng(1.35, 103.87) }
-                val tokyo = remember { LatLng(35.6895, 139.6917) }
-                val coroutineScope = rememberCoroutineScope()
-                val cameraPositionState = rememberCameraPositionState {
-                    position = CameraPosition.fromLatLngZoom(singapore, 11f)
-                }
-                val mapProperties by remember {
-                    mutableStateOf(MapProperties(mapType = MapType.NORMAL))
-                }
+            var selectedTheme by rememberSaveable { mutableStateOf(ThemeOption.SYSTEM) }
+            val systemInDarkTheme = isSystemInDarkTheme()
+            val isDark = when (selectedTheme) {
+                ThemeOption.SYSTEM -> systemInDarkTheme
+                ThemeOption.LIGHT -> false
+                ThemeOption.DARK -> true
+            }
 
-                Column(
-                    modifier = Modifier.fillMaxSize().systemBarsPadding()
+            MapsComposeSampleTheme(darkTheme = isDark) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
                 ) {
-                    Button(
-                        onClick = {
-                            coroutineScope.launch {
-                                // This would previously hang indefinitely in Lite Mode!
-                                // Now it falls back to instantaneous movement and completes the coroutine.
-                                val newTarget = if (cameraPositionState.position.target == singapore) {
-                                    tokyo
-                                } else {
-                                    singapore
-                                }
-                                cameraPositionState.animate(CameraUpdateFactory.newLatLng(newTarget))
-                            }
-                        },
-                        modifier = Modifier.padding(16.dp)
-                    ) {
-                        Text("Animate Camera (Tests Fix)")
-                    }
-
-                    Box(
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        GoogleMap(
-                            modifier = Modifier.matchParentSize(),
-                            googleMapOptionsFactory = { GoogleMapOptions().liteMode(true) },
-                            cameraPositionState = cameraPositionState,
-                            properties = mapProperties,
-                        )
-                    }
+                    LiteModeScreen(
+                        selectedTheme = selectedTheme,
+                        onSelectTheme = { selectedTheme = it },
+                        isDark = isDark,
+                        systemInDarkTheme = systemInDarkTheme
+                    )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Minimal dark JSON style for Lite Mode maps.
+ */
+private const val DARK_STYLE_JSON = """[
+  {"elementType": "geometry", "stylers": [{"color": "#242f3e"}]},
+  {"elementType": "labels.text.stroke", "stylers": [{"color": "#242f3e"}]},
+  {"elementType": "labels.text.fill", "stylers": [{"color": "#746855"}]},
+  {"featureType": "administrative.locality", "elementType": "labels.text.fill", "stylers": [{"color": "#d59563"}]},
+  {"featureType": "poi", "elementType": "labels.text.fill", "stylers": [{"color": "#d59563"}]},
+  {"featureType": "poi.park", "elementType": "geometry", "stylers": [{"color": "#263c3f"}]},
+  {"featureType": "poi.park", "elementType": "labels.text.fill", "stylers": [{"color": "#6b9a76"}]},
+  {"featureType": "road", "elementType": "geometry", "stylers": [{"color": "#38414e"}]},
+  {"featureType": "road", "elementType": "geometry.stroke", "stylers": [{"color": "#212a37"}]},
+  {"featureType": "road", "elementType": "labels.text.fill", "stylers": [{"color": "#9ca5b3"}]},
+  {"featureType": "road.highway", "elementType": "geometry", "stylers": [{"color": "#746855"}]},
+  {"featureType": "water", "elementType": "geometry", "stylers": [{"color": "#17263c"}]},
+  {"featureType": "water", "elementType": "labels.text.fill", "stylers": [{"color": "#515c6d"}]}
+]"""
+
+@Composable
+fun LiteModeScreen(
+    selectedTheme: ThemeOption,
+    onSelectTheme: (ThemeOption) -> Unit,
+    isDark: Boolean,
+    systemInDarkTheme: Boolean,
+) {
+    val singapore = remember { LatLng(1.35, 103.87) }
+    val tokyo = remember { LatLng(35.6895, 139.6917) }
+    val coroutineScope = rememberCoroutineScope()
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(singapore, 11f)
+    }
+
+    var selectedMapType by rememberSaveable { mutableStateOf(MapType.NORMAL) }
+
+    // Dynamically apply the dark JSON style to the Lite map whenever dark mode is active
+    val mapProperties = remember(selectedMapType, isDark) {
+        MapProperties(
+            mapType = selectedMapType,
+            mapStyleOptions = if (isDark) MapStyleOptions(DARK_STYLE_JSON) else null
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Button(
+            onClick = {
+                coroutineScope.launch {
+                    val newTarget = if (cameraPositionState.position.target == singapore) tokyo else singapore
+                    cameraPositionState.animate(CameraUpdateFactory.newLatLng(newTarget))
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Animate Camera")
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Map Type:", style = MaterialTheme.typography.labelLarge)
+            FilterChip(
+                selected = selectedMapType == MapType.NORMAL,
+                onClick = { selectedMapType = MapType.NORMAL },
+                label = { Text("Normal") }
+            )
+            FilterChip(
+                selected = selectedMapType == MapType.TERRAIN,
+                onClick = { selectedMapType = MapType.TERRAIN },
+                label = { Text("Terrain") }
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Theme:", style = MaterialTheme.typography.labelLarge)
+            FilterChip(
+                selected = selectedTheme == ThemeOption.SYSTEM,
+                onClick = { onSelectTheme(ThemeOption.SYSTEM) },
+                label = { Text("System") }
+            )
+            FilterChip(
+                selected = selectedTheme == ThemeOption.LIGHT,
+                onClick = { onSelectTheme(ThemeOption.LIGHT) },
+                label = { Text("Light") }
+            )
+            FilterChip(
+                selected = selectedTheme == ThemeOption.DARK,
+                onClick = { onSelectTheme(ThemeOption.DARK) },
+                label = { Text("Dark") }
+            )
+        }
+
+        Text(
+            text = "Active: ${if (isDark) "Dark" else "Light"}" +
+                if (selectedTheme == ThemeOption.SYSTEM) " (System: ${if (systemInDarkTheme) "Dark" else "Light"})" else "",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            GoogleMap(
+                modifier = Modifier.fillMaxSize(),
+                googleMapOptionsFactory = {
+                    GoogleMapOptions()
+                        .liteMode(true)
+                        .mapType(selectedMapType.value)
+                },
+                cameraPositionState = cameraPositionState,
+                properties = mapProperties,
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a guide and sample demonstrating how to configure and use a Lite Mode map that automatically follows the Android system theme and applies custom JSON dark styling.

### Background
In Lite Mode, the Google Maps Android SDK serves static pre-rendered tiles and does not support dynamic `MapColorScheme`. To display a dark-themed map in Lite Mode, developers should observe the system setting using `isSystemInDarkTheme()` and dynamically supply a custom JSON map style via `MapProperties.mapStyleOptions`.

### Changes Included
- **Documentation Guide**: `docs/lite-mode-dark-theme.md` detailing the root cause, step-by-step implementation, and best practices.
- **Sample App**: `LiteModeActivity.kt` updated to demonstrate following the system theme dynamically, with user override options and camera animations.
- **Back-Reference Links**: `LiteModeActivity.kt` links to `docs/lite-mode-dark-theme.md`, and the guide links back to the sample via relative path.
- **README**: Added link to the new guide under the Documentation section.
- **Regression Tests**: Added unit/instrumentation tests in `GoogleMapViewTests.kt` asserting option preservation in Lite Mode.