### PR TITLE
build: migrate unit test coverage from JaCoCo to Kover

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
     - name: Build modules
-      run: ./gradlew build jacocoTestReport -x :maps-app:generateDebugScreenshotTestConfig -x :maps-app:generateReleaseScreenshotTestConfig --stacktrace
+      run: ./gradlew build koverXmlReportDebug -x :maps-app:generateDebugScreenshotTestConfig -x :maps-app:generateReleaseScreenshotTestConfig --stacktrace
 
     - name: Run Screenshot Tests
       run: ./gradlew :maps-app:validateDebugScreenshotTest

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.android.gradle.plugin)
     implementation(libs.dokka.plugin)
-    implementation(libs.org.jacoco.core)
+    implementation(libs.kover.gradle.plugin)
     implementation(libs.gradle.maven.publish.plugin)
 
 }

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -17,20 +17,17 @@
 // buildSrc/src/main/kotlin/PublishingConventionPlugin.kt
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.*
-import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
-import org.gradle.api.tasks.testing.Test
-import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
 
             applyPlugins()
-            configureJacoco()
+            configureKover()
             configureVanniktechPublishing()
         }
     }
@@ -38,47 +35,19 @@ class PublishingConventionPlugin : Plugin<Project> {
     private fun Project.applyPlugins() {
         apply(plugin = "com.android.library")
         apply(plugin = "org.jetbrains.dokka")
-        apply(plugin = "org.gradle.jacoco")
+        apply(plugin = "org.jetbrains.kotlinx.kover")
         apply(plugin = "com.vanniktech.maven.publish")
     }
 
-    private fun Project.configureJacoco() {
-        configure<JacocoPluginExtension> {
-            toolVersion = "0.8.15" // Compatible with newer JDKs
-        }
-
-        // AGP 9.0+ built-in Jacoco support or manual configuration.
-        // We create a "jacocoTestReport" task to match the CI workflow.
-        
-        tasks.register<JacocoReport>("jacocoTestReport") {
-             // Dependencies
-             dependsOn("testDebugUnitTest")
-             
-             reports {
-                 xml.required.set(true)
-                 html.required.set(true)
-             }
-             
-             // Source directories
-             val mainSrc = "${layout.projectDirectory}/src/main/java"
-             sourceDirectories.setFrom(files(mainSrc))
-             
-             // Class directories - AGP 9's built-in Kotlin compiler outputs to
-             // intermediates/built_in_kotlinc/, not the legacy tmp/kotlin-classes/ path.
-             classDirectories.setFrom(
-                 fileTree(layout.buildDirectory.dir("intermediates/built_in_kotlinc/debug")) {
-                     include("**/classes/**")
-                 },
-                 fileTree(layout.buildDirectory.dir("intermediates/javac/debug")) {
-                     include("**/classes/**")
-                     exclude("**/R.class", "**/R\$*.class", "**/BuildConfig.class")
-                 }
-             )
-             
-             // Execution data from the unit test task
-             executionData.setFrom(fileTree(layout.buildDirectory.get()) {
-                 include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
-             })
+    private fun Project.configureKover() {
+        configure<KoverProjectExtension> {
+            reports {
+                filters {
+                    excludes {
+                        androidGeneratedClasses()
+                    }
+                }
+            }
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ buildscript {
         classpath(libs.maps.secrets.plugin)
         classpath(libs.kotlin.gradle.plugin)
         classpath(libs.dokka.plugin)
-        classpath(libs.jacoco.android.plugin)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,8 +39,7 @@ junit = "4.13.2"
 junitktx = "1.3.0"
 leakcanaryAndroid = "2.14"
 mockk = "1.14.11"
-org-jacoco-core = "0.8.15"
-jacoco-plugin = "0.2.1"
+kover = "0.9.9"
 robolectric = "4.16.1"
 screenshot = "0.0.1-alpha14"
 truth = "1.4.5"
@@ -83,12 +82,11 @@ androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", vers
 androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitktx" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidCore" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxtest" }
-jacoco-android-plugin = { module = "com.mxalbert.gradle:jacoco-android", version.ref = "jacoco-plugin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
-org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
+kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 test-junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

Migrates unit test coverage from JaCoCo to [kotlinx-kover](https://github.com/Kotlin/kotlinx-kover) 0.9.9.

**Why:** the `jacocoTestReport` task in `PublishingConventionPlugin` hardcoded AGP 9 internal intermediate paths (`intermediates/built_in_kotlinc/debug`) to work around JaCoCo not understanding the built-in Kotlin compiler output. Those paths are implementation details that can break on any AGP update. Kover (first-party JetBrains, actively maintained against AGP 9) integrates through AGP's variant APIs, so the manual report wiring is deleted. The unused `com.mxalbert.gradle:jacoco-android` classpath dependency (last released for AGP 8.x) is removed as well.

## Changes

- `PublishingConventionPlugin` applies `org.jetbrains.kotlinx.kover` with `androidGeneratedClasses()` excluded, replacing the hand-rolled `jacocoTestReport` task.
- `test.yml` runs `koverXmlReportDebug` instead of `jacocoTestReport`.
- **Unchanged:** the instrumented-test coverage in `instrumentation-test.yml` (`createDebugCoverageReport` on `maps-app`) uses AGP's built-in on-device JaCoCo, which Kover does not replace, so it stays as is.

## Verification

Full CI command `./gradlew build koverXmlReportDebug -x :maps-app:generateDebugScreenshotTestConfig -x :maps-app:generateReleaseScreenshotTestConfig --stacktrace` passes locally (11m 51s). Kover reports generate for all three library modules; `maps-compose-utils` (the only module with host unit tests) shows captured coverage, and the modules without host tests report 0% exactly as JaCoCo did.
